### PR TITLE
rename page metadata to metatags, containing both meta and link elements

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -61,7 +61,7 @@ class DrupalCe {
           message: 'Malformed API response. Please make sure to install Custom Elements renderer: https://www.drupal.org/project/lupus_ce_renderer'})
       }
       this.$currentPage.title = data.title
-      this.$currentPage.metadata = this.processMetaData(data.metatags)
+      this.$currentPage.metatags = this.processMetatags(data.metatags)
       this.$currentPage.content = data.content
       this.$currentPage.breadcrumbs = Array.isArray(data.breadcrumbs) ? data.breadcrumbs : [],
       this.$currentPage.messages = this.processMessages(data.messages)
@@ -75,23 +75,23 @@ class DrupalCe {
   }
 
   /**
-   * Generates `hid` keys for metatags and links.
+   * Generates `hid` keys for metatags.
    */
-  processMetaData(metadata) {
-    const { meta = [], link = [] } = metadata;
-    metadata.meta = [...meta].map((metaObject) => {
+  processMetatags(metatags) {
+    const { meta = [], link = [] } = metatags;
+    metatags.meta = [...meta].map((metaObject) => {
       // Simply take the first key as hid, e.g. 'name'.
       const firstKey = Object.keys(metaObject)[0]
       metaObject.hid = firstKey == 'property' ? metaObject[firstKey] : `${firstKey}:${metaObject[firstKey]}`
       return metaObject
     })
-    metadata.link = [...link].map((linkObject) => {
+    metatags.link = [...link].map((linkObject) => {
       // Simply take the first key as hid, e.g. 'name'.
       const firstKey = Object.keys(linkObject)[0]
       linkObject.hid = `${firstKey}:${linkObject[firstKey]}`
       return linkObject
     })
-    return metadata
+    return metatags
   }
 
   /**

--- a/scaffold/pages/_.vue
+++ b/scaffold/pages/_.vue
@@ -14,8 +14,8 @@ export default {
   head () {
     return {
       title: this.page.title,
-      meta: this.page.metadata.meta,
-      link: this.page.metadata.link
+      meta: this.page.metatags.meta,
+      link: this.page.metatags.link
     }
   }
 }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -31,3 +31,29 @@ describe('ssr-without-proxy', () => {
     expect(body).toContain('<meta data-n-head="ssr" name="title" content="Example page | Drupal 9 Custom Elements Demo" data-hid="name:title">')
   })
 })
+
+describe('ssr-with-proxy', () => {
+  setupTest({
+    testDir: __dirname,
+    fixture: '../example',
+    server: true,
+    config: {
+      'nuxtjs-drupal-ce': {
+        useProxy: 'always'
+      }
+    }
+  })
+
+  beforeAll(async () => {
+    await exec('cd example && ../bin/nuxt-drupal-ce-init.js')
+  }, 60000)
+
+  test('should render example-page', async () => {
+    setupBaseURL()
+    const { body } = await get('/example-page')
+    expect(body).toContain('This is an example-page.')
+    expect(body).toMatch(/<a .*href="\/node\/1".*>/)
+    expect(body).not.toContain('<drupal-markup>')
+    expect(body).toContain('<meta data-n-head="ssr" name="title" content="Example page | Drupal 9 Custom Elements Demo" data-hid="name:title">')
+  })
+})


### PR DESCRIPTION
Let's follow the naming of the page response provided by lupus_ce_renderer.