### PR TITLE
feat: Add blocks integration

### DIFF
--- a/lib/plugin.mjs
+++ b/lib/plugin.mjs
@@ -149,8 +149,10 @@ const storeModule = {
         localTasks: local_tasks,
         // eslint-disable-next-line camelcase
         page_layout,
-        settings,
-        blocks: blocks || {}
+        settings
+      }
+      if (blocks) {
+        page.blocks = blocks
       }
       const { meta = [], link = [] } = page.metatags
       page.metatags.meta = [...meta].map((metaObject) => {

--- a/lib/plugin.mjs
+++ b/lib/plugin.mjs
@@ -138,7 +138,7 @@ const storeModule = {
   getters: {},
   mutations: {
     // eslint-disable-next-line camelcase
-    page (state, { statusCode, title, content, breadcrumbs, metatags, local_tasks, page_layout, settings }) {
+    page (state, { statusCode, title, content, breadcrumbs, metatags, local_tasks, page_layout, settings, blocks }) {
       const page = {
         statusCode,
         title,
@@ -149,7 +149,8 @@ const storeModule = {
         localTasks: local_tasks,
         // eslint-disable-next-line camelcase
         page_layout,
-        settings
+        settings,
+        blocks
       }
       const { meta = [], link = [] } = page.metatags
       page.metatags.meta = [...meta].map((metaObject) => {

--- a/lib/plugin.mjs
+++ b/lib/plugin.mjs
@@ -150,7 +150,7 @@ const storeModule = {
         // eslint-disable-next-line camelcase
         page_layout,
         settings,
-        blocks
+        blocks: blocks || {}
       }
       const { meta = [], link = [] } = page.metatags
       page.metatags.meta = [...meta].map((metaObject) => {


### PR DESCRIPTION
Providing `blocks` via a new method on \Drupal\lupus_ce_renderer\CustomElementsRenderer::getDynamicContent(). This change exposes it, so it's available to nuxtjs.

Needs the changes in https://www.drupal.org/project/lupus_ce_renderer/issues/3337979