### PR TITLE
fix: Set status code for API error responses containing page data

### DIFF
--- a/src/runtime/composables/useDrupalCe.ts
+++ b/src/runtime/composables/useDrupalCe.ts
@@ -1,4 +1,5 @@
-import { useRuntimeConfig, useState, useFetch, navigateTo, createError, useRoute, h, resolveComponent } from '#imports'
+import { callWithNuxt } from '#app'
+import { useRuntimeConfig, useState, useFetch, navigateTo, createError, useRoute, h, resolveComponent, setResponseStatus, useNuxtApp } from '#imports'
 export const useDrupalCe = () => {
   /**
    * Fetches page data from Drupal, handles redirects, errors and messages
@@ -6,6 +7,7 @@ export const useDrupalCe = () => {
    * @param useFetchOptions Optional Nuxt useFetch options
    */
   const fetchPage = async (path: string, useFetchOptions = {}) => {
+    const nuxtApp = useNuxtApp()
     const config = useRuntimeConfig()
     const baseURL = config.public.drupalCe.baseURL
 
@@ -35,6 +37,7 @@ export const useDrupalCe = () => {
     }
 
     if (error.value) {
+      callWithNuxt(nuxtApp, setResponseStatus, [error.value.status])
       page.value = error.value?.data
     }
 

--- a/test/errorhandling.test.ts
+++ b/test/errorhandling.test.ts
@@ -8,12 +8,11 @@ describe('Module error handling', async () => {
     configFile: 'nuxt.config4test'
   })
   it('renders Drupal error page', async () => {
-    const html = await $fetch('/node/404')
-    expect(html).toContain('The requested page could not be found')
-    // This doesn't pass yet, because the module doesn't set the status code for Drupal error pages
-    // Uncomment when fixed
-    // const { status } = await fetch('/node/404')
-    // expect(status).toEqual(404)
+    const response = await fetch('/node/404')
+    expect(response.status).toEqual(404)
+    // HTML returned from SSR page to contain
+    // (same as what $fetch returns, but can't use $fetch because the promise rejects)
+    expect(await response.text()).toContain('The requested page could not be found')
   })
   it('handles 500 statusCode', async () => {
     const response = await fetch('/error500')


### PR DESCRIPTION
Solves #123. I also added test coverage for it.
I had to use callWithNuxt to use Nuxt composable (setResponseStatus) after an async call.