### PR TITLE
docs: use new `nuxi module add` command and improve setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nuxtjs-drupal-ce - Nuxt.js Drupal Custom Elements Connector
+# nuxtjs-drupal-ce - Nuxt Drupal Custom Elements Connector
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
@@ -21,13 +21,19 @@ The 2.x version of the module is compatible with Nuxt 3. For a Nuxt 2 compatible
 
 ## Setup
 
-1. Add `nuxtjs-drupal-ce` dependency to your Nuxt project
+1. Go to your Nuxt project. If necessary, start a new one:
+
+```bash
+npx nuxi@latest init <project-name>
+```
+
+2. Add the `nuxtjs-drupal-ce` module to your Nuxt project
 
 ```bash
 npx nuxi@latest module add drupal-ce
 ```
 
-2. Add `nuxtjs-drupal-ce` to the `modules` section of `nuxt.config.js`
+3. Configure `nuxtjs-drupal-ce` in your `nuxt.config.js`
 
 ```js
 export default defineNuxtConfig({
@@ -44,7 +50,7 @@ export default defineNuxtConfig({
 The module defaults work well with [Lupus Decoupled Drupal](https://www.drupal.org/project/lupus_decoupled) - in that case setting the
 `drupalBaseUrl` is enough to get started.
 
-3. Get started quickly by scaffolding initial files:
+5. Scaffold initial files. After scaffolding, edit them as suiting.
 ```bash
 rm -f app.vue && npx nuxt-drupal-ce-init
 ```

--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ export default defineNuxtConfig({
   }
 })
 ```
-
-The module defaults work well with [Lupus Decoupled Drupal](https://www.drupal.org/project/lupus_decoupled) - in that case setting the
+The module defaults work well with [Lupus Decoupled Drupal](https://drupal.org/project/lupus_decoupled) - in that case setting the
 `drupalBaseUrl` is enough to get started.
 
-5. Scaffold initial files. After scaffolding, edit them as suiting.
+4. Scaffold initial files. After scaffolding, edit them as suiting.
 ```bash
 rm -f app.vue && npx nuxt-drupal-ce-init
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 2.x version of the module is compatible with Nuxt 3. For a Nuxt 2 compatible
 1. Add `nuxtjs-drupal-ce` dependency to your Nuxt project
 
 ```bash
-yarn add nuxtjs-drupal-ce@beta # or npm install nuxtjs-drupal-ce@beta
+npx nuxi@latest module add drupal-ce
 ```
 
 2. Add `nuxtjs-drupal-ce` to the `modules` section of `nuxt.config.js`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
