### PR TITLE
fix: augment `@nuxt/schema` rather than `nuxt/schema`

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,7 +2,7 @@ import type { ModuleOptions } from './module'
 
 // Define the type for the runtime-config,.
 // see https://nuxt.com/docs/guide/going-further/runtime-config#manually-typing-runtime-config
-declare module 'nuxt/schema' {
+declare module '@nuxt/schema' {
   interface PublicRuntimeConfig {
     drupalCe: ModuleOptions
   }


### PR DESCRIPTION
Context: https://github.com/nuxt/nuxt/issues/28332

`nuxt/schema` is a re-export of `@nuxt/schema` for users to use. Modules should not augment it, or it may end up overwriting the inferred types from `@nuxt/schema`.

(We made the change in https://github.com/nuxt/module-builder/pull/295 (released in v0.8.0 of `@nuxt/module-builder`) to avoid doing this in `@nuxt/module-builder` itself.)