### PR TITLE
fix: module does not work without nuxt-i18n

### DIFF
--- a/playground/layouts/default.vue
+++ b/playground/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <SiteLanguageSwitcher v-if="$i18n" />
+    <SiteLanguageSwitcher v-if="useNuxtApp().$i18n" />
     <NavigationMain />
     <SiteMessages />
     <div id="main">

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -83,7 +83,7 @@ export const useDrupalCe = () => {
    */
   const getCeApiEndpoint = (localize: boolean = true) => {
     const nuxtApp = useNuxtApp()
-    if (localize && nuxtApp.$i18n?.locale && nuxtApp.$i18n.locale.value !== nuxtApp.$i18n.defaultLocale) {
+    if (localize && nuxtApp.$i18n?.locale?.value && nuxtApp.$i18n.locale.value !== nuxtApp.$i18n.defaultLocale) {
       return `${config.ceApiEndpoint}/${nuxtApp.$i18n.locale.value}`
     }
     return config.ceApiEndpoint

--- a/test/unit/ceApiEndpoint.test.ts
+++ b/test/unit/ceApiEndpoint.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment nuxt
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { useDrupalCe } from '../../src/runtime/composables/useDrupalCe'
+
+const { useRuntimeConfigMock, useNuxtAppMock } = vi.hoisted(() => ({
+  useRuntimeConfigMock: vi.fn().mockReturnValue({
+    public: { drupalCe: { ceApiEndpoint: '/ce-api' } }
+  }),
+  useNuxtAppMock: vi.fn()
+}))
+
+describe('useDrupalCe() - getCeApiEndpoint() - handling of i18n localization in API endpoint paths', () => {
+  beforeEach(() => {
+    mockNuxtImport('useRuntimeConfig', () => useRuntimeConfigMock)
+    mockNuxtImport('useNuxtApp', () => useNuxtAppMock)
+  })
+
+  it('returns base endpoint without i18n', () => {
+    useNuxtAppMock.mockReturnValue({ $i18n: undefined })
+    const { getCeApiEndpoint } = useDrupalCe()
+    expect(getCeApiEndpoint()).toBe('/ce-api')
+  })
+
+  it('returns base endpoint for default locale', () => {
+    useNuxtAppMock.mockReturnValue({
+      $i18n: { locale: { value: 'en' }, defaultLocale: 'en' }
+    })
+    const { getCeApiEndpoint } = useDrupalCe()
+    expect(getCeApiEndpoint()).toBe('/ce-api')
+  })
+
+  it('returns localized endpoint for non-default locale', () => {
+    useNuxtAppMock.mockReturnValue({
+      $i18n: { locale: { value: 'de' }, defaultLocale: 'en' }
+    })
+    const { getCeApiEndpoint } = useDrupalCe()
+    expect(getCeApiEndpoint()).toBe('/ce-api/de')
+  })
+
+  it('returns base endpoint when localize=false', () => {
+    useNuxtAppMock.mockReturnValue({
+      $i18n: { locale: { value: 'de' }, defaultLocale: 'en' }
+    })
+    const { getCeApiEndpoint } = useDrupalCe()
+    expect(getCeApiEndpoint(false)).toBe('/ce-api')
+  })
+})


### PR DESCRIPTION
ran into an issue that nuxt-i18n is required, although it should be optional