### PR TITLE
feat: MCD-500 add drupal-markup-embeds-component

### DIFF
--- a/playground/components/global/drupal-markup-embeds.ts
+++ b/playground/components/global/drupal-markup-embeds.ts
@@ -1,0 +1,77 @@
+import { h, Fragment, defineComponent } from 'vue';
+import type { VNode } from 'vue';
+
+export default defineComponent({
+  name: 'DrupalMarkupEmbeds',
+  render(): VNode {
+    if (!this.$slots.default) {
+      return h(Fragment);
+    }
+
+    // Process the VNode tree to replace div elements with data-ce-embed
+    const processVNode = (vnode: VNode): VNode => {
+      // If not a VNode object or is a text node, return it unchanged
+      if (!vnode || typeof vnode !== 'object' || typeof vnode.type === 'undefined') {
+        return vnode;
+      }
+
+      // If this is a div with data-ce-embed attribute, replace it with the corresponding slot content
+      const embedId = vnode.props?.['data-ce-embed'] as string;
+      const slotName = embedId ? `ce-embed-${embedId}` : null;
+
+      if (vnode.type === 'div' &&
+        vnode.props &&
+        slotName &&
+        this.$slots[slotName]) {
+        // Get slot content and return the first node or wrap in Fragment if multiple
+        const slotContent = this.$slots[slotName]();
+        if (slotContent.length === 1) {
+          return slotContent[0];
+        } else {
+          return h(Fragment, {}, slotContent);
+        }
+      }
+
+      // For component VNodes with children
+      if (vnode.children) {
+        // If children is an array, process each child
+        if (Array.isArray(vnode.children)) {
+          return {
+            ...vnode,
+            children: vnode.children.map(child => processVNode(child as VNode))
+          };
+        }
+        // If children is an object (like a slots object)
+        else if (typeof vnode.children === 'object' && vnode.children !== null) {
+          const processedChildren: Record<string, any> = {};
+          for (const key in vnode.children) {
+            if (Object.prototype.hasOwnProperty.call(vnode.children, key)) {
+              processedChildren[key] = processVNode((vnode.children as Record<string, any>)[key]);
+            }
+          }
+          return {
+            ...vnode,
+            children: processedChildren
+          };
+        }
+      }
+
+      return vnode;
+    };
+
+    // Get the default slot content
+    const defaultSlotContent = this.$slots.default();
+
+    // Process all VNodes in the default slot
+    try {
+      const processedContent = defaultSlotContent.map(vnode => processVNode(vnode as VNode));
+
+      // Always use Fragment and never wrap in a div
+      return h(Fragment, {}, processedContent);
+    } catch (error) {
+      console.error('Error processing content:', error);
+      // Fall back to unprocessed content if there's an error
+      return h(Fragment, {}, defaultSlotContent);
+    }
+  }
+});

--- a/playground/components/global/drupal-markup-embeds.ts
+++ b/playground/components/global/drupal-markup-embeds.ts
@@ -1,10 +1,70 @@
+/**
+ * DrupalMarkupEmbeds Component
+ *
+ * A component that renders HTML markup with embedded custom elements.
+ * Supports two modes of operation:
+ *
+ * 1. Slot Mode - Using Vue slots for content and embeds
+ * 2. JSON Mode - Using props for content and embeds
+ *
+ * @example Slot Mode Usage:
+ * ```vue
+ * <DrupalMarkupEmbeds>
+ *   <template #default>
+ *     <div>Main content with <div data-ce-embed="my-embed"></div> placeholder</div>
+ *   </template>
+ *   <template #ce-embed-my-embed>
+ *     <MyComponent>This replaces the placeholder</MyComponent>
+ *   </template>
+ * </DrupalMarkupEmbeds>
+ * ```
+ *
+ * @example JSON Mode Usage:
+ * ```vue
+ * <DrupalMarkupEmbeds
+ *   content="<div>Main content with <div data-ce-embed=\"my-embed\"></div> placeholder</div>"
+ *   :ce-embed-my-embed="{ element: 'my-component', prop: 'value' }"
+ * />
+ * ```
+ */
+
 import { h, Fragment, defineComponent } from 'vue';
 import type { VNode } from 'vue';
+// useDrupalCe is auto-imported by Nuxt
 
 export default defineComponent({
   name: 'DrupalMarkupEmbeds',
+
+  inheritAttrs: false, // Prevent attributes from being passed to the root element
+
+  props: {
+    /**
+     * HTML content with embed placeholders (for JSON mode)
+     * When provided, the component operates in JSON mode
+     * Embeds are specified as <div data-ce-embed="ID"></div>
+     * @optional
+     */
+    content: {
+      type: String,
+      default: null,
+      required: false
+    }
+  },
+
+  /**
+   * @slot default - Main content with embed placeholders (for Slot mode)
+   * @slot ce-embed-* - Content for embeds, where * is the embed ID
+   */
+
   render(): VNode {
-    if (!this.$slots.default) {
+    // useDrupalCe is auto-imported by Nuxt
+    const { renderCustomElements } = useDrupalCe();
+
+    // Determine which mode we're in - slot mode or JSON mode
+    const isJsonMode = typeof this.content !== 'undefined' && this.content !== null;
+
+    // If we don't have content from either source, return empty fragment
+    if (!isJsonMode && !this.$slots.default) {
       return h(Fragment);
     }
 
@@ -17,18 +77,16 @@ export default defineComponent({
 
       // If this is a div with data-ce-embed attribute, replace it with the corresponding slot content
       const embedId = vnode.props?.['data-ce-embed'] as string;
-      const slotName = embedId ? `ce-embed-${embedId}` : null;
-
-      if (vnode.type === 'div' &&
-        vnode.props &&
-        slotName &&
-        this.$slots[slotName]) {
-        // Get slot content and return the first node or wrap in Fragment if multiple
-        const slotContent = this.$slots[slotName]();
-        if (slotContent.length === 1) {
-          return slotContent[0];
-        } else {
-          return h(Fragment, {}, slotContent);
+      if (embedId && vnode.type === 'div') {
+        const slotName = `ce-embed-${embedId}`;
+        if (this.$slots[slotName]) {
+          // Get slot content and return the first node or wrap in Fragment if multiple
+          const slotContent = this.$slots[slotName]();
+          if (slotContent.length === 1) {
+            return slotContent[0];
+          } else {
+            return h(Fragment, {}, slotContent);
+          }
         }
       }
 
@@ -59,19 +117,102 @@ export default defineComponent({
       return vnode;
     };
 
-    // Get the default slot content
-    const defaultSlotContent = this.$slots.default();
+    // Creates a composed view of HTML content with embedded custom elements
+    const createJsonContent = () => {
+      if (!this.content) return h(Fragment);
 
-    // Process all VNodes in the default slot
+      // Process content by finding embeds and creating parts without extra wrappers
+      const parts = [];
+      let lastIndex = 0;
+      const embedRegex = /<div\s+data-ce-embed="([^"]+)"[^>]*><\/div>/g;
+      let match;
+      let content = this.content;
+
+      // Find all embed placeholders
+      const embedInfos = [];
+      while ((match = embedRegex.exec(content)) !== null) {
+        const [fullMatch, embedId] = match;
+        const slotName = `ce-embed-${embedId}`;
+
+        embedInfos.push({
+          id: embedId,
+          slotName,
+          start: match.index,
+          end: match.index + fullMatch.length,
+          match: fullMatch
+        });
+      }
+
+      // If no embeds, just return the content as HTML
+      if (embedInfos.length === 0) {
+        return h('span', { innerHTML: content });
+      }
+
+      // Process content in order
+      embedInfos.forEach((info, index) => {
+        // Add content before this embed
+        if (info.start > lastIndex) {
+          const htmlContent = content.substring(lastIndex, info.start);
+          if (htmlContent.trim()) {
+            parts.push(h('span', { innerHTML: htmlContent }));
+          }
+        }
+
+        // Add the embed content if available
+        if (info.slotName in this.$attrs) {
+          const embedContent = this.$attrs[info.slotName];
+          if (embedContent) {
+            // Use renderCustomElements to create the component
+            const rendered = renderCustomElements(embedContent);
+            if (rendered) {
+              parts.push(rendered);
+            }
+          }
+        } else {
+          // Keep the placeholder if no content is available
+          parts.push(h('div', { 'data-ce-embed': info.id }));
+        }
+
+        lastIndex = info.end;
+      });
+
+      // Add any remaining content
+      if (lastIndex < content.length) {
+        const htmlContent = content.substring(lastIndex);
+        if (htmlContent.trim()) {
+          parts.push(h('span', { innerHTML: htmlContent }));
+        }
+      }
+
+      // Return all parts in a Fragment
+      return h(Fragment, {}, parts);
+    };
+
     try {
-      const processedContent = defaultSlotContent.map(vnode => processVNode(vnode as VNode));
+      // Handle slot-based mode
+      if (!isJsonMode && this.$slots.default) {
+        const defaultSlotContent = this.$slots.default();
+        const processedContent = defaultSlotContent.map(vnode => processVNode(vnode as VNode));
+        return h(Fragment, {}, processedContent);
+      }
+      // Handle JSON mode
+      else if (isJsonMode) {
+        return createJsonContent();
+      }
 
-      // Always use Fragment and never wrap in a div
-      return h(Fragment, {}, processedContent);
+      // Single fallback to empty fragment
+      return h(Fragment);
     } catch (error) {
       console.error('Error processing content:', error);
-      // Fall back to unprocessed content if there's an error
-      return h(Fragment, {}, defaultSlotContent);
+
+      // Simple fallback based on mode
+      if (isJsonMode && this.content) {
+        return h('span', { innerHTML: this.content });
+      } else if (this.$slots.default) {
+        return h(Fragment, {}, this.$slots.default());
+      }
+
+      return h(Fragment);
     }
   }
 });

--- a/test/unit/components/drupal-markup-embed-json.test.ts
+++ b/test/unit/components/drupal-markup-embed-json.test.ts
@@ -1,0 +1,268 @@
+// @vitest-environment nuxt
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineComponent } from 'vue'
+import { useNuxtApp } from "#imports"
+
+describe('DrupalMarkupEmbeds JSON Mode', () => {
+  // Register the test components we'll need
+  const TestEmbed = defineComponent({
+    name: 'TestEmbed',
+    inheritAttrs: false,
+    props: {
+      prop1: String
+    },
+    template: '<div class="test-embed">{{ prop1 }}</div>'
+  })
+
+  const SecondEmbed = defineComponent({
+    name: 'SecondEmbed',
+    inheritAttrs: false,
+    props: {
+      prop2: String
+    },
+    template: '<div class="second-embed">{{ prop2 }}</div>'
+  })
+
+  // Register components globally
+  const app = useNuxtApp()
+  app.vueApp.component('TestEmbed', TestEmbed)
+  app.vueApp.component('SecondEmbed', SecondEmbed)
+  // Note: DrupalMarkup is already available in the test playground
+
+  // Helper function to normalize HTML (remove extra whitespace between tags)
+  const normalizeHtml = (html) => {
+    return html
+      .replace(/>\s+</g, '><') // Remove whitespace between tags
+      .replace(/\s+/g, ' ')    // Replace multiple spaces with single space
+      .trim();                 // Trim leading/trailing whitespace
+  }
+
+  it('renders basic HTML content without embeds', async () => {
+    const { renderCustomElements } = useDrupalCe()
+
+    const wrapper = await mountSuspended(defineComponent({
+      setup() {
+        return {
+          component: renderCustomElements({
+            element: 'drupal-markup-embeds',
+            content: '<p>Basic <strong>HTML</strong> content without embeds</p>'
+          })
+        }
+      },
+      template: '<component :is="component" />'
+    }))
+
+    // The content should be wrapped in a div with our content inside
+    const html = normalizeHtml(wrapper.html());
+    expect(html).toMatch(/<div.*?><p>Basic <strong>HTML<\/strong> content without embeds<\/p><\/div>/);
+  })
+
+  it('renders content with a single embed', async () => {
+    const { renderCustomElements } = useDrupalCe()
+
+    const wrapper = await mountSuspended(defineComponent({
+      setup() {
+        return {
+          component: renderCustomElements({
+            element: 'drupal-markup-embeds',
+            content: '<div>Content with <div data-ce-embed="1"></div> embed</div>',
+            'ce-embed-1': {
+              element: 'test-embed',
+              prop1: 'Embedded content'
+            }
+          })
+        }
+      },
+      template: '<component :is="component" />'
+    }))
+
+    // Normalize and check the HTML structure
+    const html = normalizeHtml(wrapper.html());
+
+    // Check for the content segment before embed
+    expect(html).toEqual(/<div class="markup-segment"><div>Content with <\/div><\/div>/);
+
+    // Check for the embedded content
+    expect(html).toMatch(/<div class="embed-wrapper"><div class="test-embed">Embedded content<\/div><\/div>/);
+
+    // Check for the content segment after embed
+    expect(html).toMatch(/<div class="markup-segment"> embed<\/div>/);
+
+    // Verify the embed placeholder is not present
+    expect(html).not.toContain('data-ce-embed="1"');
+  })
+
+  it('renders table with embedded content', async () => {
+    const { renderCustomElements } = useDrupalCe()
+
+    const wrapper = await mountSuspended(defineComponent({
+      setup() {
+        return {
+          component: renderCustomElements({
+            element: 'drupal-markup-embeds',
+            content: `
+              <table>
+                <tbody>
+                  <tr>
+                    <td>Cell content before embed</td>
+                    <td><div data-ce-embed="table-embed"></div></td>
+                    <td>Cell content after embed</td>
+                  </tr>
+                </tbody>
+              </table>
+            `,
+            'ce-embed-table-embed': {
+              element: 'test-embed',
+              prop1: 'Table embedded content'
+            }
+          })
+        }
+      },
+      template: '<component :is="component" />'
+    }))
+
+    // Normalize and check the HTML structure
+    const html = normalizeHtml(wrapper.html());
+
+    // Verify the table structure starts correctly
+    expect(html).toMatch(/<div class="markup-segment"><table><tbody><tr><td>Cell content before embed<\/td>/);
+
+    // Verify the embedded content
+    expect(html).toMatch(/<div class="embed-wrapper"><div class="test-embed">Table embedded content<\/div><\/div>/);
+
+    // Verify the table structure ends correctly
+    expect(html).toMatch(/<div class="markup-segment"><td>Cell content after embed<\/td><\/tr><\/tbody><\/table>/);
+
+    // Verify the embed placeholder is not present
+    expect(html).not.toContain('data-ce-embed="table-embed"');
+  })
+
+  it('handles missing embed content gracefully', async () => {
+    const { renderCustomElements } = useDrupalCe()
+
+    const wrapper = await mountSuspended(defineComponent({
+      setup() {
+        return {
+          component: renderCustomElements({
+            element: 'drupal-markup-embeds',
+            content: '<div>Content with <div data-ce-embed="missing"></div> missing embed</div>'
+          })
+        }
+      },
+      template: '<component :is="component" />'
+    }))
+
+    // Normalize and check the HTML structure
+    const html = normalizeHtml(wrapper.html());
+
+    // The missing embed placeholder should remain in the output
+    expect(html).toMatch(/<div>Content with <div data-ce-embed="missing"><\/div> missing embed<\/div>/);
+  })
+
+  it('renders with drupal-markup element type', async () => {
+    const { renderCustomElements } = useDrupalCe()
+
+    const wrapper = await mountSuspended(defineComponent({
+      setup() {
+        return {
+          component: renderCustomElements({
+            element: 'drupal-markup-embeds',
+            content: '<div>Content with <div data-ce-embed="markup"></div></div>',
+            'ce-embed-markup': {
+              element: 'drupal-markup',
+              content: '<span class="special-markup">Special markup content</span>'
+            }
+          })
+        }
+      },
+      template: '<component :is="component" />'
+    }))
+
+    // Normalize and check the HTML structure
+    const html = normalizeHtml(wrapper.html());
+
+    // Check for content before embed
+    expect(html).toMatch(/<div class="markup-segment"><div>Content with\s*<\/div><\/div>/);
+
+    // Check for the drupal-markup content
+    expect(html).toMatch(/<div class="embed-wrapper"><span class="special-markup">Special markup content<\/span><\/div>/);
+
+    // Check for content after embed (could be empty or just closing div)
+    expect(html).toMatch(/<div class="markup-segment">\s*<\/div><\/div>/);
+
+    // Verify the embed placeholder is not present
+    expect(html).not.toContain('data-ce-embed="markup"');
+  })
+
+  it('renders content with multiple embeds in nested HTML', async () => {
+    const { renderCustomElements } = useDrupalCe()
+
+    const wrapper = await mountSuspended(defineComponent({
+      setup() {
+        return {
+          component: renderCustomElements({
+            element: 'drupal-markup-embeds',
+            content: `
+              <article>
+                <header>
+                  <h1>Article with Embeds</h1>
+                  <div class="meta">
+                    <div data-ce-embed="header-embed"></div>
+                  </div>
+                </header>
+                <section>
+                  <p>First paragraph</p>
+                  <div class="embedded-content">
+                    <div data-ce-embed="1"></div>
+                  </div>
+                  <p>Middle paragraph</p>
+                  <blockquote>
+                    <div data-ce-embed="2"></div>
+                  </blockquote>
+                  <p>Last paragraph</p>
+                </section>
+              </article>
+            `,
+            'ce-embed-header-embed': {
+              element: 'drupal-markup',
+              content: '<span class="date">January 15, 2023</span>'
+            },
+            'ce-embed-1': {
+              element: 'test-embed',
+              prop1: 'First nested embed'
+            },
+            'ce-embed-2': {
+              element: 'second-embed',
+              prop2: 'Second nested embed'
+            }
+          })
+        }
+      },
+      template: '<component :is="component" />'
+    }))
+
+    // Normalize and check the HTML structure
+    const html = normalizeHtml(wrapper.html());
+
+    // Check for the article structure
+    expect(html).toMatch(/<article>/);
+    expect(html).toMatch(/<header>/);
+    expect(html).toMatch(/<h1>Article with Embeds<\/h1>/);
+    expect(html).toMatch(/<div class="meta">/);
+
+    // Check for the embedded components
+    expect(html).toMatch(/<span class="date">January 15, 2023<\/span>/);
+    expect(html).toMatch(/<div class="test-embed">First nested embed<\/div>/);
+    expect(html).toMatch(/<div class="second-embed">Second nested embed<\/div>/);
+
+    // Verify the structure has the right parts after embeds
+    expect(html).toMatch(/<p>Middle paragraph<\/p>/);
+    expect(html).toMatch(/<p>Last paragraph<\/p>/);
+
+    // Verify the embed placeholders are not present
+    expect(html).not.toContain('data-ce-embed="1"');
+    expect(html).not.toContain('data-ce-embed="2"');
+    expect(html).not.toContain('data-ce-embed="header-embed"');
+  })
+})

--- a/test/unit/components/drupal-markup-embeds.test.ts
+++ b/test/unit/components/drupal-markup-embeds.test.ts
@@ -1,0 +1,211 @@
+// test/unit/components/drupal-markup-embeds.test.ts
+// @vitest-environment nuxt
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineComponent, h } from 'vue'
+
+describe('DrupalMarkupEmbeds component', () => {
+  it('renders basic content without embeds', async () => {
+    const TestComponent = defineComponent({
+      template: `
+        <DrupalMarkupEmbeds>
+          <template #default>
+            <p>Basic content without embeds</p>
+          </template>
+        </DrupalMarkupEmbeds>
+      `
+    })
+
+    const wrapper = await mountSuspended(TestComponent)
+    expect(wrapper.html()).toBe('<p>Basic content without embeds</p>')
+  })
+
+  it('replaces single embed with corresponding slot content', async () => {
+    const TestComponent = defineComponent({
+      template: `
+        <DrupalMarkupEmbeds>
+          <template #default>
+            <h2>Content with embed</h2>
+            <div data-ce-embed="123"></div>
+          </template>
+          <template #ce-embed-123>
+            <p>Embedded content</p>
+          </template>
+        </DrupalMarkupEmbeds>
+      `
+    })
+
+    const wrapper = await mountSuspended(TestComponent)
+    expect(wrapper.html()).toBe('<h2>Content with embed</h2>\n<p>Embedded content</p>')
+  })
+
+  it('replaces multiple embeds with corresponding slot content', async () => {
+    const TestComponent = defineComponent({
+      template: `
+        <DrupalMarkupEmbeds>
+          <template #default>
+            <h2>This is the main content</h2>
+            <div data-ce-embed="321"></div>
+            <p>Some html <strong>markup</strong></p>
+            <div class="foo">
+              <div data-ce-embed="456"></div>
+            </div>
+          </template>
+          <template #ce-embed-321>
+            <div>Embed 321</div>
+          </template>
+          <template #ce-embed-456>
+            <div>Embed <strong>456</strong></div>
+          </template>
+        </DrupalMarkupEmbeds>
+      `
+    })
+
+    const wrapper = await mountSuspended(TestComponent)
+
+    // Verify the exact HTML structure with newlines
+    const expectedHTML =
+      '<h2>This is the main content</h2>\n' +
+      '<div>Embed 321</div>\n' +
+      '<p>Some html <strong>markup</strong></p>\n' +
+      '<div class="foo">\n' +
+      '  <div>Embed <strong>456</strong></div>\n' +
+      '</div>';
+
+    expect(wrapper.html()).toBe(expectedHTML)
+  })
+
+  it('preserves embed div if no matching slot is found', async () => {
+    const TestComponent = defineComponent({
+      template: `
+        <DrupalMarkupEmbeds>
+          <template #default>
+            <h2>Content with missing embed</h2>
+            <div data-ce-embed="missing"></div>
+          </template>
+        </DrupalMarkupEmbeds>
+      `
+    })
+
+    const wrapper = await mountSuspended(TestComponent)
+    const expectedHTML =
+      '<h2>Content with missing embed</h2>\n' +
+      '<div data-ce-embed="missing"></div>';
+
+    expect(wrapper.html()).toBe(expectedHTML)
+  })
+
+  it('handles nested embeds properly', async () => {
+    const TestComponent = defineComponent({
+      template: `
+        <DrupalMarkupEmbeds>
+          <template #default>
+            <div class="outer">
+              <div data-ce-embed="outer"></div>
+            </div>
+          </template>
+          <template #ce-embed-outer>
+            <div class="inner-container">
+              Outer content
+              <div data-ce-embed="inner"></div>
+            </div>
+          </template>
+          <template #ce-embed-inner>
+            <span>Inner content</span>
+          </template>
+        </DrupalMarkupEmbeds>
+      `
+    })
+
+    const wrapper = await mountSuspended(TestComponent)
+
+    // Verify the exact HTML structure with nested elements
+    const expectedHTML =
+      '<div class="outer">\n' +
+      '  <div class="inner-container"> Outer content <div data-ce-embed="inner"></div>\n' +
+      '  </div>\n' +
+      '</div>';
+
+    expect(wrapper.html()).toBe(expectedHTML)
+  })
+
+  it('handles complex embeds with multiple elements', async () => {
+    const TestComponent = defineComponent({
+      template: `
+        <DrupalMarkupEmbeds>
+          <template #default>
+            <article>
+              <h1>Article title</h1>
+              <div data-ce-embed="complex"></div>
+              <p>Conclusion paragraph</p>
+            </article>
+          </template>
+          <template #ce-embed-complex>
+            <h2>Section heading</h2>
+            <p>First paragraph</p>
+            <p>Second paragraph</p>
+            <ul>
+              <li>List item 1</li>
+              <li>List item 2</li>
+            </ul>
+          </template>
+        </DrupalMarkupEmbeds>
+      `
+    })
+
+    const wrapper = await mountSuspended(TestComponent)
+
+    const expectedHTML =
+      '<article>\n' +
+      '  <h1>Article title</h1>\n' +
+      '  <h2>Section heading</h2>\n' +
+      '  <p>First paragraph</p>\n' +
+      '  <p>Second paragraph</p>\n' +
+      '  <ul>\n' +
+      '    <li>List item 1</li>\n' +
+      '    <li>List item 2</li>\n' +
+      '  </ul>\n' +
+      '  <p>Conclusion paragraph</p>\n' +
+      '</article>';
+
+    expect(wrapper.html()).toBe(expectedHTML)
+  })
+
+  it('handles embeds within a table structure', async () => {
+    const TestComponent = defineComponent({
+      template: `
+        <DrupalMarkupEmbeds>
+          <template #default>
+            <table style="border: 1px solid black; border-collapse: collapse;">
+              <tbody>
+                <tr>
+                  <td style="border: 1px solid black; padding: 8px;">
+                    Cell content before embed
+                    <div data-ce-embed="table-embed"></div>
+                    Cell content after embed
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </template>
+          <template #ce-embed-table-embed>
+            <span style="color: blue; font-weight: bold;">Embedded table content</span>
+          </template>
+        </DrupalMarkupEmbeds>
+      `
+    })
+
+    const wrapper = await mountSuspended(TestComponent)
+
+    const expectedHTML =
+      '<table style="border: 1px solid black; border-collapse: collapse;">\n' +
+      '  <tbody>\n' +
+      '    <tr>\n' +
+      '      <td style="border: 1px solid black; padding: 8px;"> Cell content before embed <span style="color: blue; font-weight: bold;">Embedded table content</span> Cell content after embed </td>\n' +
+      '    </tr>\n' +
+      '  </tbody>\n' +
+      '</table>';
+
+    expect(wrapper.html()).toBe(expectedHTML)
+  })
+})


### PR DESCRIPTION
 add a  component that renders HTML markup with embedded custom elements.
 Supports two modes of operation:
 
 1. Slot Mode - Using Vue slots for content and embeds
  2. JSON Mode - Using props for content and embeds


Slot mode actually works already in this PR. JSON mode we ran into the challenge of not being able to insert slots into a html string in vue again - without parsing the html.