### PR TITLE
fix: prevent fatal error inside error logging if event is not defined.

### DIFF
--- a/src/runtime/server/plugins/errorLogger.ts
+++ b/src/runtime/server/plugins/errorLogger.ts
@@ -6,9 +6,11 @@ export default defineNitroPlugin((nitro: any) => {
 
   if (serverLogLevel === 'error' || serverLogLevel === 'info') {
     nitro.hooks.hook('error', (error: any, { event }: any) => {
-      const url = getRequestURL(event)
-      const fullUrl = url.origin + url.pathname + url.search
-      console.error(`[${event?.node.req.method}] ${fullUrl} - ${error}`)
+      if (event) {
+        const url = getRequestURL(event)
+        const fullUrl = url.origin + url.pathname + url.search
+        console.error(`[${event?.node.req.method}] ${fullUrl} - ${error}`)
+      }
     })
   }
 

--- a/src/runtime/server/plugins/errorLogger.ts
+++ b/src/runtime/server/plugins/errorLogger.ts
@@ -6,11 +6,12 @@ export default defineNitroPlugin((nitro: any) => {
 
   if (serverLogLevel === 'error' || serverLogLevel === 'info') {
     nitro.hooks.hook('error', (error: any, { event }: any) => {
-      if (event) {
-        const url = getRequestURL(event)
-        const fullUrl = url.origin + url.pathname + url.search
-        console.error(`[${event?.node.req.method}] ${fullUrl} - ${error}`)
+      if (!event) {
+        return
       }
+      const url = getRequestURL(event)
+      const fullUrl = url.origin + url.pathname + url.search
+      console.error(`[${event?.node.req.method}] ${fullUrl} - ${error}`)
     })
   }
 

--- a/src/runtime/server/plugins/errorLogger.ts
+++ b/src/runtime/server/plugins/errorLogger.ts
@@ -7,6 +7,7 @@ export default defineNitroPlugin((nitro: any) => {
   if (serverLogLevel === 'error' || serverLogLevel === 'info') {
     nitro.hooks.hook('error', (error: any, { event }: any) => {
       if (!event) {
+        // Ignore errors that are unrelated to requests.
         return
       }
       const url = getRequestURL(event)


### PR DESCRIPTION
Please note: bug report from someone who doesn't know Nuxt and knows only a little about npm.

I was setting up an application locally according to a README I was given. When accessing the app, I got the following screen:
<img width="1439" height="859" alt="Screenshot 2025-08-31 at 21 39 57" src="https://github.com/user-attachments/assets/85aae2e3-6b43-4428-bca5-f5a44bcc7826" />

So... the error handler itself crashes while/before logging an error message, if `event` is not defined.

The above fatal error seems to prevent any error output to STDOUT/STDERR on the app I'm running locally using `npm run dev`.

For context: 
* A key/cert file was not being defined anywhere, so that is likely the reason that 'event' is not defined -- because an error is thrown "too early", before any request is really being processed? 
* When I put an `if (event) {` around the code, I _did_ see an error on STDOUT/STDERR, so I could see what to fix:
```
 ERROR  [uncaughtException] ENOENT: no such file or directory, open './cf.local.pem'    10:16:57 PM

    at Object.openSync (node:fs:561:18)
    at [.... etc] 
```
So, 
* the PR currently at least fixes _that_ (lack of error message in my case);
* since I did not add any `} else {   console.error( ...  ) }`, the above error is apparently output somewhere else in the app (another 'hook implementation' or their caller?). If I add this `} else {`, I get the error message twice. So I'm unsure that an `} else {` is necessary here.
