### PR TITLE
refactor: improve fetchPage and getPage to use a single shared state with working refs

### DIFF
--- a/playground/pages/[...slug].vue
+++ b/playground/pages/[...slug].vue
@@ -16,9 +16,6 @@ const layout = getPageLayout(page)
 usePageHead(page)
 
 definePageMeta({
-  key: (route) => {
-    const params = new URLSearchParams(route.query as Record<string, any>).toString()
-    return params ? `${route.path}?${params}` : route.path
-  },
+  key: (route) => route.path,
 })
 </script>

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -138,10 +138,15 @@ export const useDrupalCe = () => {
       serverResponse.value = useRequestEvent(nuxtApp).context.drupalCeCustomPageResponse
     }
 
-    // Handle serverResponse path: manually populate cache and skip API call
+    // Get page data and result ref - either from serverResponse or API
+    let page: any
+    let error: any
+    let dataRef: Ref<DrupalCePage>
+
     if (serverResponse.value) {
-      let page = serverResponse.value._data
-      let error = serverResponse.value.error
+      // ServerResponse path: skip API call, use provided data
+      page = serverResponse.value._data
+      error = serverResponse.value.error
 
       if (serverResponse.value._data) {
         passThroughHeaders(nuxtApp, serverResponse.value.headers)
@@ -150,65 +155,16 @@ export const useDrupalCe = () => {
       // Clear serverResponse immediately on server (data will be in cache for hydration)
       serverResponse.value = null
 
-      if (page?.messages) {
-        pushMessagesToState(page.messages)
-      }
-
-      if (page?.redirect) {
-        await callWithNuxt(nuxtApp, navigateTo, [
-          page.redirect.url,
-          { external: page.redirect.external, redirectCode: page.redirect.statusCode, replace: true },
-        ])
-        // Redirect aborts rendering, but store empty page in cache and return ref to it
-        // This matches the structure of the normal path
-        nuxtApp.payload.data[useFetchOptions.key] = createEmptyPage()
-        currentPageKey.value = useFetchOptions.key
-        return toRef(nuxtApp.payload.data, useFetchOptions.key)
-      }
-
-      if (error) {
-        const errorData = error.data
-
-        // Validate that error response has complete page structure
-        const isValidPageStructure = errorData &&
-          typeof errorData.title === 'string' &&
-          typeof errorData.content === 'object' &&
-          typeof errorData.metatags === 'object'
-
-        if (!isValidPageStructure || config.customErrorPages) {
-          (overrideErrorHandler || pageErrorHandler)({ value: error }, { config, nuxtApp })
-        }
-        else {
-          // Backend returned a complete custom error page
-          nuxtApp.payload.data[useFetchOptions.key] = {
-            ...errorData,
-            key: useFetchOptions.key,
-          }
-
-          if (import.meta.server) {
-            callWithNuxt(nuxtApp, setResponseStatus, [error.statusCode])
-          }
-        }
-      }
-      else if (page) {
-        // Store page data in cache
-        nuxtApp.payload.data[useFetchOptions.key] = {
-          ...page,
-          key: useFetchOptions.key,
-        }
-      }
-
-      // Store the current page key
-      currentPageKey.value = useFetchOptions.key
-
-      // Return ref linked to cache entry
-      return toRef(nuxtApp.payload.data, useFetchOptions.key)
+      // Create ref that will be linked to cache after processing
+      dataRef = toRef(nuxtApp.payload.data, useFetchOptions.key)
     }
-
-    // Normal path: fetch from API using useCeApi
-    const result = await useCeApi(path, useFetchOptions, true, skipDrupalCeApiProxy)
-    let page = result.data.value
-    let error = result.error.value
+    else {
+      // Normal path: fetch from API
+      const result = await useCeApi(path, useFetchOptions, true, skipDrupalCeApiProxy)
+      page = result.data.value
+      error = result.error.value
+      dataRef = result.data
+    }
 
     if (page?.messages) {
       pushMessagesToState(page.messages)
@@ -219,57 +175,48 @@ export const useDrupalCe = () => {
         page.redirect.url,
         { external: page.redirect.external, redirectCode: page.redirect.statusCode, replace: true },
       ])
-      // Replace incomplete redirect response with empty page structure
-      // This prevents errors when components try to access page.metatags.meta etc.
-      result.data.value = createEmptyPage()
+      // Redirect aborts rendering - replace with empty page structure
+      dataRef.value = createEmptyPage()
       currentPageKey.value = useFetchOptions.key
-      return result.data
+      return dataRef
     }
 
     if (error) {
       const errorData = error.data
 
       // Validate that error response has complete page structure
-      // Backend MUST return a complete page structure for custom error pages
       const isValidPageStructure = errorData &&
         typeof errorData.title === 'string' &&
         typeof errorData.content === 'object' &&
         typeof errorData.metatags === 'object'
 
-      // When customErrorPages is enabled, always throw to let custom error handler process it
-      // Otherwise, only throw if backend didn't return a complete error page
       if (!isValidPageStructure || config.customErrorPages) {
-        // Fatal error or custom error pages enabled - delegate to error handler
         (overrideErrorHandler || pageErrorHandler)({ value: error }, { config, nuxtApp })
       }
       else {
-        // Backend returned a complete custom error page and customErrorPages is disabled
-        // Add key to the data
-        result.data.value = {
+        // Backend returned a complete custom error page
+        dataRef.value = {
           ...errorData,
           key: useFetchOptions.key,
         }
 
-        // Set response status for SSR
         if (import.meta.server) {
           callWithNuxt(nuxtApp, setResponseStatus, [error.statusCode])
         }
       }
     }
     else if (page) {
-      // For successful pages, add key to the data
-      result.data.value = {
+      // Store successful page data
+      dataRef.value = {
         ...page,
         key: useFetchOptions.key,
       }
     }
 
-    // Store the current page key so getPage() can look up this data in the useFetch cache
-    // This allows layout components (breadcrumbs, etc.) to access the current page data
+    // Store the current page key for getPage() lookup
     currentPageKey.value = useFetchOptions.key
 
-    // Return the useFetch data ref directly - each component gets its own ref based on key
-    return result.data
+    return dataRef
   }
 
   /**

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -13,6 +13,21 @@ export const useDrupalCe = () => {
   const privateConfig = import.meta.server && useRuntimeConfig().drupalCe
 
   /**
+   * Returns an empty page structure with default values
+   */
+  const createEmptyPage = (): DrupalCePage => ({
+    breadcrumbs: [],
+    content: {},
+    content_format: 'json',
+    local_tasks: { primary: [], secondary: [] },
+    settings: {},
+    messages: [],
+    metatags: { meta: [], link: [], jsonld: [] },
+    page_layout: 'default',
+    title: '',
+  })
+
+  /**
    * Processes the given fetchOptions to apply module defaults
    * @param fetchOptions Optional Nuxt useFetch options
    * @param skipDrupalCeApiProxy Force skip the Drupal CE API proxy. Defaults to false.
@@ -144,8 +159,11 @@ export const useDrupalCe = () => {
           page.redirect.url,
           { external: page.redirect.external, redirectCode: page.redirect.statusCode, replace: true },
         ])
-        // Redirect aborts rendering, return empty page (will never be accessed)
-        return getPage()
+        // Redirect aborts rendering, but store empty page in cache and return ref to it
+        // This matches the structure of the normal path
+        nuxtApp.payload.data[useFetchOptions.key] = createEmptyPage()
+        currentPageKey.value = useFetchOptions.key
+        return toRef(nuxtApp.payload.data, useFetchOptions.key)
       }
 
       if (error) {
@@ -323,17 +341,7 @@ export const useDrupalCe = () => {
         return nuxtApp.payload.data[key]
       }
       // Return empty page data if no page has been fetched yet
-      return {
-        breadcrumbs: [],
-        content: {},
-        content_format: 'json',
-        local_tasks: { primary: [], secondary: [] },
-        settings: {},
-        messages: [],
-        metatags: { meta: [], link: [], jsonld: [] },
-        page_layout: 'default',
-        title: '',
-      }
+      return createEmptyPage()
     })
   }
 

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -121,7 +121,6 @@ export const useDrupalCe = () => {
    */
   const fetchPage = async (path: string, useFetchOptions: UseFetchOptions<any> = {}, overrideErrorHandler?: (error?: any) => void, skipDrupalCeApiProxy: boolean = false): Promise<Ref<DrupalCePage>> => {
     const nuxtApp = useNuxtApp()
-    const serverResponse = useState('server-response', () => null)
     const currentPageKey = useState<string>('drupal-ce-current-page-key')
 
     // Remove trailing slash from path key as it might cause issues in SSG.
@@ -132,28 +131,25 @@ export const useDrupalCe = () => {
         : ''
     useFetchOptions.key = `page-${sanitizedPathKey}${params}${skipDrupalCeApiProxy ? '-direct' : '-proxy'}`
 
-    // Check if page data is provided by server response (e.g. form submission via POST)
+    // Check if page data is provided by custom page response (e.g. form submission via POST)
     // This is only available during SSR
-    if (import.meta.server) {
-      serverResponse.value = useRequestEvent(nuxtApp).context.drupalCeCustomPageResponse
-    }
+    const customPageResponse = import.meta.server
+      ? useRequestEvent(nuxtApp).context.drupalCeCustomPageResponse
+      : null
 
-    // Get page data and result ref - either from serverResponse or API
+    // Get page data and result ref - either from customPageResponse or API
     let page: any
     let error: any
     let dataRef: Ref<DrupalCePage>
 
-    if (serverResponse.value) {
-      // ServerResponse path: skip API call, use provided data
-      page = serverResponse.value._data
-      error = serverResponse.value.error
+    if (customPageResponse) {
+      // Custom response path: skip API call, use provided data
+      page = customPageResponse._data
+      error = customPageResponse.error
 
-      if (serverResponse.value._data) {
-        passThroughHeaders(nuxtApp, serverResponse.value.headers)
+      if (customPageResponse._data) {
+        passThroughHeaders(nuxtApp, customPageResponse.headers)
       }
-
-      // Clear serverResponse immediately on server (data will be in cache for hydration)
-      serverResponse.value = null
 
       // Create ref that will be linked to cache after processing
       dataRef = toRef(nuxtApp.payload.data, useFetchOptions.key)

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -137,47 +137,42 @@ export const useDrupalCe = () => {
       ? useRequestEvent(nuxtApp).context.drupalCeCustomPageResponse
       : null
 
-    // Get page data and result ref - either from customPageResponse or API
-    let page: any
+    // Get page ref and error - either from customPageResponse or API
+    let pageRef: Ref<DrupalCePage>
     let error: any
-    let dataRef: Ref<DrupalCePage>
 
     if (customPageResponse) {
       // Custom response path: skip API call, use provided data
-      page = customPageResponse._data
+      pageRef = toRef(nuxtApp.payload.data, useFetchOptions.key)
+      pageRef.value = customPageResponse._data
       error = customPageResponse.error
 
       if (customPageResponse._data) {
         passThroughHeaders(nuxtApp, customPageResponse.headers)
       }
-
-      // Create ref that will be linked to cache after processing
-      dataRef = toRef(nuxtApp.payload.data, useFetchOptions.key)
     }
     else {
       // Normal path: fetch from API
       const result = await useCeApi(path, useFetchOptions, true, skipDrupalCeApiProxy)
-      page = result.data.value
+      pageRef = result.data
       error = result.error.value
-      dataRef = result.data
     }
 
-    if (page?.messages) {
-      pushMessagesToState(page.messages)
+    // Process messages
+    if (pageRef.value?.messages) {
+      pushMessagesToState(pageRef.value.messages)
     }
 
-    if (page?.redirect) {
+    // Handle redirect
+    if (pageRef.value?.redirect) {
       await callWithNuxt(nuxtApp, navigateTo, [
-        page.redirect.url,
-        { external: page.redirect.external, redirectCode: page.redirect.statusCode, replace: true },
+        pageRef.value.redirect.url,
+        { external: pageRef.value.redirect.external, redirectCode: pageRef.value.redirect.statusCode, replace: true },
       ])
-      // Redirect aborts rendering - replace with empty page structure
-      dataRef.value = createEmptyPage()
-      currentPageKey.value = useFetchOptions.key
-      return dataRef
+      pageRef.value = createEmptyPage()
     }
-
-    if (error) {
+    // Handle error
+    else if (error) {
       const errorData = error.data
 
       // Validate that error response has complete page structure
@@ -188,31 +183,29 @@ export const useDrupalCe = () => {
 
       if (!isValidPageStructure || config.customErrorPages) {
         (overrideErrorHandler || pageErrorHandler)({ value: error }, { config, nuxtApp })
+        pageRef.value = createEmptyPage()
       }
       else {
         // Backend returned a complete custom error page
-        dataRef.value = {
-          ...errorData,
-          key: useFetchOptions.key,
-        }
+        pageRef.value = errorData
 
         if (import.meta.server) {
           callWithNuxt(nuxtApp, setResponseStatus, [error.statusCode])
         }
       }
     }
-    else if (page) {
-      // Store successful page data
-      dataRef.value = {
-        ...page,
-        key: useFetchOptions.key,
-      }
+    // Handle missing page
+    else if (!pageRef.value) {
+      pageRef.value = createEmptyPage()
     }
+
+    // Add key to page
+    pageRef.value.key = useFetchOptions.key
 
     // Store the current page key for getPage() lookup
     currentPageKey.value = useFetchOptions.key
 
-    return dataRef
+    return pageRef
   }
 
   /**

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -219,6 +219,10 @@ export const useDrupalCe = () => {
         page.redirect.url,
         { external: page.redirect.external, redirectCode: page.redirect.statusCode, replace: true },
       ])
+      // Replace incomplete redirect response with empty page structure
+      // This prevents errors when components try to access page.metatags.meta etc.
+      result.data.value = createEmptyPage()
+      currentPageKey.value = useFetchOptions.key
       return result.data
     }
 

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -5,7 +5,7 @@ import type { Ref, ComputedRef, Component, VNode } from 'vue'
 import { getDrupalBaseUrl, getMenuBaseUrl } from './server'
 import type { UseFetchOptions, AsyncData } from '#app'
 import { callWithNuxt } from '#app'
-import { useRuntimeConfig, useState, useFetch, navigateTo, createError, h, resolveComponent, setResponseStatus, useNuxtApp, useRequestHeaders, ref, unref, watch, useRequestEvent, computed, useHead, defineComponent } from '#imports'
+import { useRuntimeConfig, useState, useFetch, navigateTo, createError, h, resolveComponent, setResponseStatus, useNuxtApp, useRequestHeaders, ref, unref, watch, useRequestEvent, computed, useHead, defineComponent, toRef } from '#imports'
 import type { DrupalCePage, DrupalCeApiResponse } from '../../types'
 
 export const useDrupalCe = () => {
@@ -106,29 +106,9 @@ export const useDrupalCe = () => {
    */
   const fetchPage = async (path: string, useFetchOptions: UseFetchOptions<any> = {}, overrideErrorHandler?: (error?: any) => void, skipDrupalCeApiProxy: boolean = false): Promise<Ref<DrupalCePage>> => {
     const nuxtApp = useNuxtApp()
-
-    // Workaround for issue - useState is not available after async call (Nuxt instance unavailable)
-    // Initialize state with default values
-    const pageState = useState<DrupalCePage>('drupal-ce-page-data', () => ({
-      breadcrumbs: [],
-      content: {},
-      content_format: 'json',
-      local_tasks: {
-        primary: [],
-        secondary: [],
-      },
-      settings: {},
-      messages: [],
-      metatags: {
-        meta: [],
-        link: [],
-        jsonld: [],
-      },
-      page_layout: 'default',
-      title: '',
-      key: undefined,  // Unique identifier used by useFetch caching
-    }))
     const serverResponse = useState('server-response', () => null)
+    const currentPageKey = useState<string>('drupal-ce-current-page-key')
+
     // Remove trailing slash from path key as it might cause issues in SSG.
     const sanitizedPathKey = path.endsWith('/') && path !== '/' ? path.slice(0, -1) : path
     const params =
@@ -137,32 +117,80 @@ export const useDrupalCe = () => {
         : ''
     useFetchOptions.key = `page-${sanitizedPathKey}${params}${skipDrupalCeApiProxy ? '-direct' : '-proxy'}`
 
+    // Check if page data is provided by server response (e.g. form submission via POST)
+    // This is only available during SSR
     if (import.meta.server) {
       serverResponse.value = useRequestEvent(nuxtApp).context.drupalCeCustomPageResponse
     }
 
-    // Check if the page data is already provided, e.g. by a form response.
-    let page: DrupalCeApiResponse | null = null
-    let error = null
-
+    // Handle serverResponse path: manually populate cache and skip API call
     if (serverResponse.value) {
+      let page = serverResponse.value._data
+      let error = serverResponse.value.error
+
       if (serverResponse.value._data) {
-        page = serverResponse.value._data
         passThroughHeaders(nuxtApp, serverResponse.value.headers)
       }
-      else if (serverResponse.value.error) {
-        error = serverResponse.value.error
+
+      // Clear serverResponse immediately on server (data will be in cache for hydration)
+      serverResponse.value = null
+
+      if (page?.messages) {
+        pushMessagesToState(page.messages)
       }
-      // Clear the server response state after it was sent to the client.
-      if (import.meta.client) {
-        serverResponse.value = null
+
+      if (page?.redirect) {
+        await callWithNuxt(nuxtApp, navigateTo, [
+          page.redirect.url,
+          { external: page.redirect.external, redirectCode: page.redirect.statusCode, replace: true },
+        ])
+        // Redirect aborts rendering, return empty page (will never be accessed)
+        return getPage()
       }
+
+      if (error) {
+        const errorData = error.data
+
+        // Validate that error response has complete page structure
+        const isValidPageStructure = errorData &&
+          typeof errorData.title === 'string' &&
+          typeof errorData.content === 'object' &&
+          typeof errorData.metatags === 'object'
+
+        if (!isValidPageStructure || config.customErrorPages) {
+          (overrideErrorHandler || pageErrorHandler)({ value: error }, { config, nuxtApp })
+        }
+        else {
+          // Backend returned a complete custom error page
+          nuxtApp.payload.data[useFetchOptions.key] = {
+            ...errorData,
+            key: useFetchOptions.key,
+          }
+
+          if (import.meta.server) {
+            callWithNuxt(nuxtApp, setResponseStatus, [error.statusCode])
+          }
+        }
+      }
+      else if (page) {
+        // Store page data in cache
+        nuxtApp.payload.data[useFetchOptions.key] = {
+          ...page,
+          key: useFetchOptions.key,
+        }
+      }
+
+      // Store the current page key
+      currentPageKey.value = useFetchOptions.key
+
+      // Return ref linked to cache entry
+      return toRef(nuxtApp.payload.data, useFetchOptions.key)
     }
-    else {
-      const result = await useCeApi(path, useFetchOptions, true, skipDrupalCeApiProxy)
-      page = result.data.value
-      error = result.error.value
-    }
+
+    // Normal path: fetch from API using useCeApi
+    const result = await useCeApi(path, useFetchOptions, true, skipDrupalCeApiProxy)
+    let page = result.data.value
+    let error = result.error.value
 
     if (page?.messages) {
       pushMessagesToState(page.messages)
@@ -173,7 +201,7 @@ export const useDrupalCe = () => {
         page.redirect.url,
         { external: page.redirect.external, redirectCode: page.redirect.statusCode, replace: true },
       ])
-      return pageState
+      return result.data
     }
 
     if (error) {
@@ -194,8 +222,8 @@ export const useDrupalCe = () => {
       }
       else {
         // Backend returned a complete custom error page and customErrorPages is disabled
-        // Update shared state and render the backend's error page
-        pageState.value = {
+        // Add key to the data
+        result.data.value = {
           ...errorData,
           key: useFetchOptions.key,
         }
@@ -207,15 +235,19 @@ export const useDrupalCe = () => {
       }
     }
     else if (page) {
-      // Be sure to assign the actual data, not the ref.
-      pageState.value = {
+      // For successful pages, add key to the data
+      result.data.value = {
         ...page,
         key: useFetchOptions.key,
       }
     }
 
-    // Always return pageState, so fetchPage() and getPage() use the same ref.
-    return pageState
+    // Store the current page key so getPage() can look up this data in the useFetch cache
+    // This allows layout components (breadcrumbs, etc.) to access the current page data
+    currentPageKey.value = useFetchOptions.key
+
+    // Return the useFetch data ref directly - each component gets its own ref based on key
+    return result.data
   }
 
   /**
@@ -275,19 +307,35 @@ export const useDrupalCe = () => {
   const getMessages = (): Ref => useState('drupal-ce-messages', () => [])
 
   /**
-   * Use page data
+   * Get the current page data ref.
+   * Returns the useFetch cached data for the current page.
+   * Layout components (breadcrumbs, page title, social share, etc.) can use this to access page data from the current route.
    */
-  const getPage = (): Ref<DrupalCePage> => useState<DrupalCePage>('drupal-ce-page-data', () => ({
-    breadcrumbs: [],
-    content: {},
-    content_format: 'json',
-    local_tasks: { primary: [], secondary: [] },
-    settings: {},
-    messages: [],
-    metatags: { meta: [], link: [], jsonld: [] },
-    page_layout: 'default',
-    title: '',
-  }))
+  const getPage = (): Ref<DrupalCePage> => {
+    const currentPageKey = useState<string>('drupal-ce-current-page-key', () => '')
+
+    // Return computed ref that looks up the current page key in the reactive Nuxt payload
+    // This properly tracks reactivity since nuxtApp.payload.data is reactive
+    return computed(() => {
+      const nuxtApp = useNuxtApp()
+      const key = currentPageKey.value
+      if (key && nuxtApp.payload.data[key]) {
+        return nuxtApp.payload.data[key]
+      }
+      // Return empty page data if no page has been fetched yet
+      return {
+        breadcrumbs: [],
+        content: {},
+        content_format: 'json',
+        local_tasks: { primary: [], secondary: [] },
+        settings: {},
+        messages: [],
+        metatags: { meta: [], link: [], jsonld: [] },
+        page_layout: 'default',
+        title: '',
+      }
+    })
+  }
 
   /**
    * Resolve a custom element into a Vue component

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -285,10 +285,15 @@ export const useDrupalCe = () => {
         watcherInitialized.value = true
         try {
           const route = useRoute()
-          watch(() => [route.path, route.query] as const, ([path, query]) => {
-            // Compute key with default proxy setting - fetchPage() will override if needed
-            currentPageKey.value = computePageKey(path, query as Record<string, any>, false)
-          }, { immediate: true })
+          const router = useRouter()
+
+          // Update key on initial load
+          currentPageKey.value = computePageKey(route.path, route.query as Record<string, any>, false)
+
+          // Use router.afterEach to ensure navigation is fully complete before updating
+          router.afterEach((to) => {
+            currentPageKey.value = computePageKey(to.path, to.query as Record<string, any>, false)
+          })
         }
         catch (e) {
           // Silently skip if not in proper Nuxt context (e.g., unit tests)

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -112,6 +112,17 @@ export const useDrupalCe = () => {
   }
 
   /**
+   * Helper to compute the page cache key
+   */
+  const computePageKey = (path: string, query: Record<string, any> = {}, skipDrupalCeApiProxy: boolean = false): string => {
+    const sanitizedPathKey = path.endsWith('/') && path !== '/' ? path.slice(0, -1) : path
+    const params = Object.keys(query).length > 0
+      ? `?${new URLSearchParams(unref(query) as Record<string, string>).toString()}`
+      : ''
+    return `page-${sanitizedPathKey}${params}${skipDrupalCeApiProxy ? '-direct' : '-proxy'}`
+  }
+
+  /**
    * Fetches page data from Drupal, handles redirects, errors and messages
    * @param path Path of the Drupal page to fetch
    * @param useFetchOptions Optional Nuxt useFetch options
@@ -123,13 +134,7 @@ export const useDrupalCe = () => {
     const nuxtApp = useNuxtApp()
     const currentPageKey = useState<string>('drupal-ce-current-page-key')
 
-    // Remove trailing slash from path key as it might cause issues in SSG.
-    const sanitizedPathKey = path.endsWith('/') && path !== '/' ? path.slice(0, -1) : path
-    const params =
-      Object.keys(useFetchOptions.query || {}).length > 0
-        ? `?${new URLSearchParams(unref(useFetchOptions.query)).toString()}`
-        : ''
-    useFetchOptions.key = `page-${sanitizedPathKey}${params}${skipDrupalCeApiProxy ? '-direct' : '-proxy'}`
+    useFetchOptions.key = computePageKey(path, useFetchOptions.query || {}, skipDrupalCeApiProxy)
 
     // Check if page data is provided by custom page response (e.g. form submission via POST)
     // This is only available during SSR
@@ -271,6 +276,25 @@ export const useDrupalCe = () => {
    */
   const getPage = (): Ref<DrupalCePage> => {
     const currentPageKey = useState<string>('drupal-ce-current-page-key', () => '')
+
+    // Set up route watcher to keep currentPageKey in sync (for KeepAlive scenarios)
+    if (import.meta.client) {
+      const watcherInitialized = useState<boolean>('drupal-ce-watcher-init', () => false)
+
+      if (!watcherInitialized.value) {
+        watcherInitialized.value = true
+        try {
+          const route = useRoute()
+          watch(() => [route.path, route.query] as const, ([path, query]) => {
+            // Compute key with default proxy setting - fetchPage() will override if needed
+            currentPageKey.value = computePageKey(path, query as Record<string, any>, false)
+          }, { immediate: true })
+        }
+        catch (e) {
+          // Silently skip if not in proper Nuxt context (e.g., unit tests)
+        }
+      }
+    }
 
     // Return computed ref that looks up the current page key in the reactive Nuxt payload
     // This properly tracks reactivity since nuxtApp.payload.data is reactive

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -181,17 +181,22 @@ export const useDrupalCe = () => {
       const errorData = error.data
 
       // Validate that error response has complete page structure
+      // Backend MUST return a complete page structure for custom error pages
       const isValidPageStructure = errorData &&
         typeof errorData.title === 'string' &&
         typeof errorData.content === 'object' &&
         typeof errorData.metatags === 'object'
 
+      // When customErrorPages is enabled, always throw to let custom error handler process it
+      // Otherwise, only throw if backend didn't return a complete error page
       if (!isValidPageStructure || config.customErrorPages) {
+        // Fatal error or custom error pages enabled - delegate to error handler
         (overrideErrorHandler || pageErrorHandler)({ value: error }, { config, nuxtApp })
         pageRef.value = createEmptyPage()
       }
       else {
-        // Backend returned a complete custom error page
+        // Backend returned a complete custom error page and customErrorPages is disabled
+        // Update shared state and render the backend's error page
         pageRef.value = errorData
 
         if (import.meta.server) {


### PR DESCRIPTION
  Key Changes

  1. Single source of truth: Page data only exists in nuxtApp.payload.data (useFetch cache)
  2. Shared state: Only stores the page key string in drupal-ce-current-page-key
  3. ServerResponse optimization: Skips API call and manually populates cache when POST response data exists
  4. Simplified redirect handling: Returns getPage() instead of defining empty page object
  5. Layout component support: getPage() provides computed ref that tracks current page via key lookup

  Architecture

  fetchPage():
  - ServerResponse path: Manually populate cache, return toRef() to cache entry
  - Normal path: Use useCeApi(), return its data ref
  - Redirect path: Return getPage() (never accessed since redirect aborts)

  getPage():
  - Returns computed ref that looks up nuxtApp.payload.data[currentPageKey.value]
  - Falls back to empty page structure if no page fetched yet
