### PR TITLE
fix: Skip API proxy routes in form handler

### DIFF
--- a/src/runtime/server/middleware/drupalFormHandler.ts
+++ b/src/runtime/server/middleware/drupalFormHandler.ts
@@ -6,6 +6,12 @@ export default defineEventHandler(async (event) => {
   const { disableFormHandler } = useRuntimeConfig().drupalCe
   const { ceApiEndpoint } = useRuntimeConfig().public.drupalCe
 
+  // Skip API proxy routes - we don't want to handle them here.
+  const currentPath = event.node.req.url?.split('?')[0] || ''
+  if (currentPath.startsWith('/api/drupal-ce/') || currentPath === '/api/drupal-ce') {
+    return
+  }
+
   if (event.node.req.method === 'POST') {
     const routesToBypass = Array.isArray(disableFormHandler) ? disableFormHandler : []
 

--- a/test/e2e/drupalFormHandler.test.ts
+++ b/test/e2e/drupalFormHandler.test.ts
@@ -53,6 +53,24 @@ describe('Drupal form handler', async () => {
     expect(await page.content()).not.toContain('Form response received, submit was successful!')
   }, 15000)
 
+  it('form handler skips API proxy routes', async () => {
+    // POST to the API proxy route - the form handler should skip it,
+    // allowing the API proxy to handle the request normally.
+    const formData = new FormData()
+    formData.append('name', 'test')
+    const response = await fetch('http://127.0.0.1:3012/api/drupal-ce/form/custom', {
+      method: 'POST',
+      body: formData,
+    })
+
+    // The API proxy should forward the request and return a response.
+    // If the form handler incorrectly processed it, the request would hang
+    // or return an error because the body was already consumed.
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    expect(text).toContain('Form response received')
+  }, 15000)
+
   it('form handler is bypassed with not matching content-type header', async () => {
     const page = await createPage('/form/custom')
     const name = page.locator('input[name="name"]')


### PR DESCRIPTION
## Summary
- Skip API proxy routes (`/api/drupal-ce/*`) in the form handler middleware
- Add test coverage for this behavior

## Problem
The form handler middleware was processing requests to the API proxy routes. This breaks XHR form-submissions!

## Solution
Add an early return in the form handler for API proxy routes. These routes should be handled by the API proxy which forwards requests to Drupal directly.

## Test plan
- [x] Added test case `form handler skips API proxy routes`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)