### PR TITLE
fix: component-preview CORS headers are wrong at runtime

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -22,32 +22,24 @@ function getCorsOrigin(nuxt: any): string | null {
   }
 }
 
-function setupCors(nuxt: any, corsOrigin: string) {
+function setupCors(nuxt: any) {
+  const { resolve } = createResolver(import.meta.url)
+
   if (nuxt.options.dev) {
-    nuxt.options.vite = nuxt.options.vite || {}
-    nuxt.options.vite.server = nuxt.options.vite.server || {}
-    nuxt.options.vite.server.cors = defu(nuxt.options.vite.server.cors, {
-      origin: [corsOrigin],
-    })
+    const corsOrigin = getCorsOrigin(nuxt)
+    if (corsOrigin) {
+      nuxt.options.vite = nuxt.options.vite || {}
+      nuxt.options.vite.server = nuxt.options.vite.server || {}
+      nuxt.options.vite.server.cors = defu(nuxt.options.vite.server.cors, {
+        origin: [corsOrigin],
+      })
+    }
   }
 
-  nuxt.options.nitro = nuxt.options.nitro || {}
-  nuxt.options.nitro.routeRules = nuxt.options.nitro.routeRules || {}
-
-  const corsHeaders = {
-    'Access-Control-Allow-Origin': corsOrigin,
-    'Access-Control-Allow-Methods': 'GET',
-  }
-
-  nuxt.options.nitro.routeRules['/_nuxt/**'] = defu(
-    nuxt.options.nitro.routeRules['/_nuxt/**'],
-    { headers: corsHeaders }
-  )
-
-  nuxt.options.nitro.routeRules['/nuxt-component-preview/**'] = defu(
-    nuxt.options.nitro.routeRules['/nuxt-component-preview/**'],
-    { headers: corsHeaders }
-  )
+  // Use a runtime Nitro plugin to set CORS headers. This ensures the
+  // correct drupalBaseUrl is used even when it differs between build-time
+  // and runtime, and covers static /_nuxt/ assets.
+  addServerPlugin(resolve('./runtime/server/plugins/componentPreviewCors'))
 }
 
 export interface ModuleOptions {
@@ -141,20 +133,15 @@ export default defineNuxtModule<ModuleOptions>({
 
     if (options.enableComponentPreview !== false) {
       await installModule('nuxt-component-preview')
+      setupCors(nuxt)
 
-      const corsOrigin = getCorsOrigin(nuxt)
-
-      if (!corsOrigin) {
-        console.warn('[nuxtjs-drupal-ce] Component preview enabled but could not derive CORS origin from drupalBaseUrl')
-      }
-      else {
-        setupCors(nuxt, corsOrigin)
-
-        if (nuxt.options.dev) {
-          // Disable appManifest in dev mode as recommended by nuxt-component-preview
-          // See https://github.com/drunomics/nuxt-component-preview#cross-domain-configuration
-          nuxt.options.experimental = nuxt.options.experimental || {}
-          nuxt.options.experimental.appManifest = false
+      if (nuxt.options.dev) {
+        // Disable appManifest in dev mode as recommended by nuxt-component-preview
+        // See https://github.com/drunomics/nuxt-component-preview#cross-domain-configuration
+        nuxt.options.experimental = nuxt.options.experimental || {}
+        nuxt.options.experimental.appManifest = false
+        const corsOrigin = getCorsOrigin(nuxt)
+        if (corsOrigin) {
           console.info('[nuxtjs-drupal-ce] Component preview enabled with CORS origin:', corsOrigin)
         }
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -140,10 +140,6 @@ export default defineNuxtModule<ModuleOptions>({
         // See https://github.com/drunomics/nuxt-component-preview#cross-domain-configuration
         nuxt.options.experimental = nuxt.options.experimental || {}
         nuxt.options.experimental.appManifest = false
-        const corsOrigin = getCorsOrigin(nuxt)
-        if (corsOrigin) {
-          console.info('[nuxtjs-drupal-ce] Component preview enabled with CORS origin:', corsOrigin)
-        }
       }
     }
 

--- a/src/runtime/server/plugins/componentPreviewCors.ts
+++ b/src/runtime/server/plugins/componentPreviewCors.ts
@@ -1,0 +1,40 @@
+import { setResponseHeader, getRequestHeader } from 'h3'
+import { defineNitroPlugin, useRuntimeConfig } from '#imports'
+
+/**
+ * Sets CORS headers at runtime for component preview paths.
+ *
+ * Uses beforeResponse to run for ALL requests including static /_nuxt/ assets,
+ * ensuring the runtime drupalBaseUrl is used even when it differs from build-time.
+ */
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('beforeResponse', (event) => {
+    const path = event.path?.split('?')[0] || ''
+    if (!path.startsWith('/_nuxt/') && !path.startsWith('/nuxt-component-preview/')) {
+      return
+    }
+
+    const drupalBaseUrl = useRuntimeConfig().public.drupalCe?.drupalBaseUrl
+    if (!drupalBaseUrl) {
+      return
+    }
+
+    let corsOrigin: string
+    try {
+      corsOrigin = new URL(drupalBaseUrl).origin
+    }
+    catch {
+      return
+    }
+
+    const origin = getRequestHeader(event, 'origin')
+    // Only set CORS headers when the request comes from the Drupal backend.
+    if (origin && origin !== corsOrigin) {
+      return
+    }
+
+    setResponseHeader(event, 'Access-Control-Allow-Origin', corsOrigin)
+    setResponseHeader(event, 'Access-Control-Allow-Methods', 'GET')
+    setResponseHeader(event, 'Access-Control-Allow-Credentials', 'true')
+  })
+})


### PR DESCRIPTION
## Summary
- Replaces build-time routeRules CORS headers with a runtime Nitro plugin using the `beforeResponse` hook
- Ensures the correct `drupalBaseUrl` is used even when build-time and runtime URLs differ
- Adds `Access-Control-Allow-Credentials: true` header for environments with basic auth
- Covers both `/_nuxt/**` and `/nuxt-component-preview/**` paths
- The runtime plugin only sets CORS headers when the request origin matches the Drupal backend

## Test plan
- [ ] Component preview works with matching build/runtime URLs
- [ ] Component preview works when runtime drupalBaseUrl differs from build-time
- [ ] CORS headers include `Access-Control-Allow-Credentials: true`
- [ ] No CORS headers set for requests from unrelated origins
- [ ] Vite dev server CORS still works in development mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)