### PR TITLE
improve: Set CORS headers for all requests from Drupal origin

### DIFF
--- a/src/runtime/server/plugins/componentPreviewCors.ts
+++ b/src/runtime/server/plugins/componentPreviewCors.ts
@@ -26,7 +26,7 @@ export default defineNitroPlugin((nitroApp) => {
 
     const origin = getRequestHeader(event, 'origin')
     // Only set CORS headers when the request comes from the Drupal backend.
-    if (origin && origin !== corsOrigin) {
+    if (!origin || origin !== corsOrigin) {
       return
     }
 

--- a/src/runtime/server/plugins/componentPreviewCors.ts
+++ b/src/runtime/server/plugins/componentPreviewCors.ts
@@ -2,18 +2,15 @@ import { setResponseHeader, getRequestHeader } from 'h3'
 import { defineNitroPlugin, useRuntimeConfig } from '#imports'
 
 /**
- * Sets CORS headers at runtime for component preview paths.
+ * Sets CORS headers at runtime for component preview requests.
  *
- * Uses beforeResponse to run for ALL requests including static /_nuxt/ assets,
- * ensuring the runtime drupalBaseUrl is used even when it differs from build-time.
+ * Uses beforeResponse to run for ALL requests including static assets,
+ * ensuring the runtime drupalBaseUrl is used even when it differs from
+ * build-time. Only sets headers when the request origin matches the
+ * Drupal backend, so regular requests are unaffected.
  */
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('beforeResponse', (event) => {
-    const path = event.path?.split('?')[0] || ''
-    if (!path.startsWith('/_nuxt/') && !path.startsWith('/nuxt-component-preview/')) {
-      return
-    }
-
     const drupalBaseUrl = useRuntimeConfig().public.drupalCe?.drupalBaseUrl
     if (!drupalBaseUrl) {
       return

--- a/test/e2e/component-preview-prod.test.ts
+++ b/test/e2e/component-preview-prod.test.ts
@@ -26,7 +26,10 @@ describe('Component Preview Production CORS', async () => {
     const assetMatch = html.match(/\/_nuxt\/([A-Za-z0-9_-]+\.js)/)
     expect(assetMatch).toBeTruthy()
 
-    const assetResponse = await fetch(`/_nuxt/${assetMatch[1]}`)
+    // Simulate a cross-origin request from the Drupal backend.
+    const assetResponse = await fetch(`/_nuxt/${assetMatch[1]}`, {
+      headers: { Origin: 'http://127.0.0.1:3015' },
+    })
     const corsOrigin = assetResponse.headers.get('access-control-allow-origin')
     const corsMethod = assetResponse.headers.get('access-control-allow-methods')
 


### PR DESCRIPTION
Instead of only covering /_nuxt/ and /nuxt-component-preview/, set CORS headers on all responses when the request origin matches the Drupal backend. This covers static assets like fonts or scripts in public/ that also need CORS for the component preview iframe.

The origin check ensures regular requests are unaffected.