### PR TITLE
fix: Forward fetchProxyHeaders in drupalFormHandler (#444)

### DIFF
--- a/playground/server/routes/ce-api/form/custom.post.ts
+++ b/playground/server/routes/ce-api/form/custom.post.ts
@@ -1,13 +1,16 @@
-export default defineEventHandler(async _ => ({
-  title: 'Form response',
-  messages: [],
-  breadcrumbs: [{frontpage: true, url: '\/', label: 'Home'}],
-  metatags: {meta: [], link: []},
-  content_format: 'json',
-  content: {
-    element: 'node',
-    content: '<p>Form response received, submit was successful!</p>',
-  },
-  page_layout: 'default',
-  local_tasks: [],
-}))
+export default defineEventHandler(async (event) => {
+  const receivedCookie = getRequestHeader(event, 'cookie') || ''
+  return {
+    title: 'Form response',
+    messages: [],
+    breadcrumbs: [{frontpage: true, url: '\/', label: 'Home'}],
+    metatags: {meta: [], link: []},
+    content_format: 'json',
+    content: {
+      element: 'node',
+      content: `<p>Form response received, submit was successful!</p><p data-received-cookie="${receivedCookie}"></p>`,
+    },
+    page_layout: 'default',
+    local_tasks: [],
+  }
+})

--- a/src/runtime/server/middleware/drupalFormHandler.ts
+++ b/src/runtime/server/middleware/drupalFormHandler.ts
@@ -4,7 +4,7 @@ import { useRuntimeConfig } from '#imports'
 
 export default defineEventHandler(async (event) => {
   const { disableFormHandler } = useRuntimeConfig().drupalCe
-  const { ceApiEndpoint } = useRuntimeConfig().public.drupalCe
+  const { ceApiEndpoint, fetchProxyHeaders } = useRuntimeConfig().public.drupalCe
 
   // Skip API proxy routes - we don't want to handle them here.
   const currentPath = event.node.req.url?.split('?')[0] || ''
@@ -41,10 +41,21 @@ export default defineEventHandler(async (event) => {
 
     if (formData) {
       const targetUrl = event.node.req.url
+      // Forward configured proxy headers (e.g. cookie) from the original request.
+      const proxyHeaders: Record<string, string> = {}
+      if (Array.isArray(fetchProxyHeaders)) {
+        for (const name of fetchProxyHeaders) {
+          const value = event.node.req.headers[name.toLowerCase()]
+          if (value) {
+            proxyHeaders[name.toLowerCase()] = Array.isArray(value) ? value.join(', ') : value
+          }
+        }
+      }
       const response = await $fetch.raw(getDrupalBaseUrl() + ceApiEndpoint + targetUrl, {
         method: 'POST',
         body: formData,
         headers: {
+          ...proxyHeaders,
           'x-form-processed': 'true',
         },
       }).catch((error) => {

--- a/test/e2e/drupalFormHandler.test.ts
+++ b/test/e2e/drupalFormHandler.test.ts
@@ -71,6 +71,31 @@ describe('Drupal form handler', async () => {
     expect(text).toContain('Form response received')
   }, 15000)
 
+  it('fetchProxyHeaders are forwarded to Drupal', async () => {
+    const page = await createPage('/form/custom')
+
+    // Set a cookie on the page before submitting.
+    await page.context().addCookies([{
+      name: 'test_session',
+      value: 'abc123',
+      domain: '127.0.0.1',
+      path: '/',
+    }])
+    await page.reload()
+
+    const name = page.locator('input[name="name"]')
+    const submit = page.locator('input[type="submit"]')
+    await name.fill('admin')
+    await submit.click()
+
+    await new Promise(resolve => setTimeout(resolve, 3000))
+
+    // The mock server echoes back received cookies in data-received-cookie attribute.
+    const content = await page.content()
+    expect(content).toContain('Form response received, submit was successful!')
+    expect(content).toContain('test_session=abc123')
+  }, 15000)
+
   it('form handler is bypassed with not matching content-type header', async () => {
     const page = await createPage('/form/custom')
     const name = page.locator('input[name="name"]')

--- a/test/e2e/drupalFormHandlerDisabled.test.ts
+++ b/test/e2e/drupalFormHandlerDisabled.test.ts
@@ -1,0 +1,40 @@
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import { setup, createPage } from '@nuxt/test-utils/e2e'
+import DrupalCe from '../../'
+import { join } from 'node:path'
+
+describe('Drupal form handler disabled via boolean', async () => {
+  await setup({
+    rootDir: join(fileURLToPath(import.meta.url), '../../../playground'),
+    nuxtConfig: {
+      modules: [
+        DrupalCe,
+      ],
+      drupalCe: {
+        drupalBaseUrl: 'http://127.0.0.1:3016',
+        ceApiEndpoint: '/ce-api',
+        disableFormHandler: true,
+      },
+    },
+    port: 3016,
+  })
+
+  it('disableFormHandler: true prevents form processing', async () => {
+    const page = await createPage('/form/custom')
+    const name = page.locator('input[name="name"]')
+    const submit = page.locator('input[type="submit"]')
+
+    expect(await name.isVisible()).toBe(true)
+    expect(await submit.isVisible()).toBe(true)
+
+    await name.fill('admin')
+    await submit.click()
+
+    await new Promise(resolve => setTimeout(resolve, 3000))
+
+    // With disableFormHandler: true, the middleware is not registered at all,
+    // so the form submission should not be processed.
+    expect(await page.content()).not.toContain('Form response received, submit was successful!')
+  }, 15000)
+})


### PR DESCRIPTION
## Summary
- Forward headers configured via `fetchProxyHeaders` (defaults to `['cookie']`) in the `drupalFormHandler` middleware
- Previously only `x-form-processed: true` was sent, breaking forms that rely on sessions/authentication
- Playground mock handler now echoes back received cookies for test verification

## Test plan
- [ ] Existing form handler tests still pass
- [ ] New test verifies cookies are forwarded to Drupal on form POST
- [ ] New test verifies `disableFormHandler: true` (boolean) completely disables the middleware

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)