### PR TITLE
chore: MCD-781: require nuxt-component-preview >= 1.0.0-beta.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
-        "nuxt-component-preview": "^1.0.0-beta.1"
+        "nuxt-component-preview": "^1.0.0-beta.9"
       },
       "bin": {
         "nuxt-drupal-ce-init": "bin/nuxt-drupal-ce-init.cjs"
@@ -10839,9 +10839,9 @@
       }
     },
     "node_modules/nuxt-component-preview": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/nuxt-component-preview/-/nuxt-component-preview-1.0.0-beta.1.tgz",
-      "integrity": "sha512-WleTomADYOo8UPk/AtJ5tPK3X422IjtUeLUMWw6WVTp5hI+a7GxGv57VMuCGPklCO1Q0UcBbV+efx3oGo2AxjQ==",
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/nuxt-component-preview/-/nuxt-component-preview-1.0.0-beta.9.tgz",
+      "integrity": "sha512-+arUwRXrwyHPPEdpujvFIOiNb+8oi2SBGo9bvD47gihVos6SB9fLtg09aIydwTQG1/nuPnpo391+eOxwlT0xXA==",
       "license": "MIT",
       "dependencies": {
         "vue-component-meta": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "defu": "^6.1.4",
-    "nuxt-component-preview": "^1.0.0-beta.1"
+    "nuxt-component-preview": "^1.0.0-beta.9"
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.10.0",


### PR DESCRIPTION
## Summary
- Bumps `nuxt-component-preview` minimum from `^1.0.0-beta.1` to `^1.0.0-beta.9`
- beta.9 adds `data-cdn-url` and `data-build-assets-dir` data-attribute overrides on `app-loader.js`, required for lupus_csr theme support where assets are served from a theme subdirectory

## Test plan
- [ ] Verify `npm install` resolves correctly
- [ ] Run existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)