### PR TITLE
feat(view-controls): add headless view-controls docs and Nuxt pager wiring

### DIFF
--- a/playground/VIEW_CONTROLS.md
+++ b/playground/VIEW_CONTROLS.md
@@ -1,0 +1,73 @@
+# View Controls (Headless Pattern)
+
+This playground note documents a **UI-agnostic** pattern for view filtering, sorting and pagination.
+
+## Goal
+
+Share logic in the module (query building, refresh, matching a target view block) while letting each downstream app choose its own UI.
+
+## Recommended shared API
+
+Create a composable in module/runtime such as `useDrupalCeViewControls()` that exposes:
+
+- `rows`
+- `pager`
+- `filters`
+- `sorts`
+- `isLoading`
+- `error`
+- `noResults`
+- `setFilter(key, value)`
+- `setSort(key, value)`
+- `setPage(page)`
+- `reset()`
+- `refresh()`
+
+## Important matching rule
+
+When a page contains multiple view blocks, always scope the refreshed result by:
+
+- `viewId`
+- `displayId`
+- `parentUuid` (when present)
+
+This prevents one block from reading another block's data.
+
+## Query conventions
+
+- Arrays should serialize as repeated `key[]` entries.
+- Normalize sort order to `ASC` / `DESC` for Drupal Views compatibility.
+
+## Runtime behavior
+
+- Debounce UI-driven refreshes.
+- Abort in-flight requests when a newer request starts.
+- Treat missing view node after refresh as potential empty state (if backend omits block on no rows).
+
+## Notes for downstream themes/apps
+
+- Keep module composable headless.
+- Implement UI in the app/theme layer (Nuxt UI, custom CSS, etc.).
+
+See `playground/composables/useDrupalCeViewControls.example.ts` for a minimal shape.
+
+## Lupus Decoupled Views compatibility
+
+This pattern is intentionally aligned with:
+
+- `lupus_decoupled/modules/lupus_decoupled_views`
+
+Expected integration contract:
+
+- exposed filters via URL query params
+- exposed sorts (`sort_by`, `sort_order`)
+- pager data (`current`, `totalPages`)
+- optional no-results message (`noResults` or `no_results`)
+- block scoping via `viewId`, `displayId`, `parentUuid`
+
+Known constraints:
+
+- payload details depend on Drupal/Lupus backend version and processor behavior
+- multiple view blocks on one page must be scoped correctly (`viewId` + `displayId` + `parentUuid`)
+- shared/overlapping exposed filter identifiers across blocks can conflict at query-string level
+- backend memory/cache issues (e.g. APCu/PHP limits) must be solved in Drupal infrastructure

--- a/playground/components/Drupal/DrupalViewsPagination.vue
+++ b/playground/components/Drupal/DrupalViewsPagination.vue
@@ -5,7 +5,7 @@
         v-if="hasPrevious"
         class="relative inline-flex min-w-10 items-center px-2 py-2 text-sm"
         :href="hrefForPage(currentPage - 1)"
-        @click="onPageClick($event, currentPage - 1)"
+        @click="goTo(currentPage - 1)"
       >
         <span class="sr-only">Previous</span>
         &lt;&lt;
@@ -27,7 +27,7 @@
           'relative inline-flex min-w-10 items-center px-4 py-2': page.index !== currentPage,
         }"
         :href="page.index === currentPage ? undefined : hrefForPage(page.index)"
-        @click="page.index === currentPage ? undefined : onPageClick($event, page.index)"
+        @click="page.index === currentPage ? undefined : goTo(page.index)"
       >
         {{ page.label }}
       </component>
@@ -43,7 +43,7 @@
         v-if="hasNext"
         class="relative inline-flex min-w-10 items-center px-2 py-2"
         :href="hrefForPage(currentPage + 1)"
-        @click="onPageClick($event, currentPage + 1)"
+        @click="goTo(currentPage + 1)"
       >
         <span class="sr-only">Next</span>
         &gt;&gt;
@@ -70,17 +70,11 @@ const emit = defineEmits<{
   'update:current': [value: number],
 }>();
 
-const attrs = useAttrs();
 const route = useRoute();
-const router = useRouter();
 
 const currentPage = computed(() => Math.max(0, props.current));
 const totalPages = computed(() => Math.max(0, props.totalPages));
 const maxLinks = computed(() => Math.max(1, props.maxLinks));
-const hasUpdateListener = computed(() => {
-  const handler = attrs['onUpdate:current'];
-  return typeof handler === 'function' || Array.isArray(handler);
-});
 
 const startIndex = computed(() => {
   if (totalPages.value <= maxLinks.value) return 0;
@@ -124,15 +118,16 @@ function hrefForPage(page: number) {
     delete query.page;
   }
 
-  return router.resolve({
-    path: route.path,
-    query,
-  }).href;
-}
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (Array.isArray(value)) {
+      for (const item of value) params.append(key, item);
+    } else if (typeof value === 'string') {
+      params.set(key, value);
+    }
+  }
 
-function onPageClick(event: MouseEvent, page: number) {
-  if (!hasUpdateListener.value) return;
-  event.preventDefault();
-  goTo(page);
+  const queryString = params.toString();
+  return queryString ? `${route.path}?${queryString}` : route.path;
 }
 </script>

--- a/playground/components/Drupal/DrupalViewsPagination.vue
+++ b/playground/components/Drupal/DrupalViewsPagination.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="views-pager">
     <nav class="isolate inline-flex -space-x-px gap-1" aria-label="Pagination">
-      <a
+      <NuxtLink
         v-if="hasPrevious"
         class="relative inline-flex min-w-10 items-center px-2 py-2 text-sm"
-        :href="hrefForPage(currentPage - 1)"
+        :to="toForPage(currentPage - 1)"
         @click="goTo(currentPage - 1)"
       >
         <span class="sr-only">Previous</span>
         &lt;&lt;
-      </a>
+      </NuxtLink>
 
       <span
         v-if="showLeftEllipsis"
@@ -19,14 +19,14 @@
       </span>
 
       <component
-        :is="page.index === currentPage ? 'span' : 'a'"
+        :is="page.index === currentPage ? 'span' : 'NuxtLink'"
         v-for="page in pageLinks"
         :key="page.index"
         :class="{
           'relative z-10 inline-flex min-w-10 items-center px-4 py-2': page.index === currentPage,
           'relative inline-flex min-w-10 items-center px-4 py-2': page.index !== currentPage,
         }"
-        :href="page.index === currentPage ? undefined : hrefForPage(page.index)"
+        :to="page.index === currentPage ? undefined : toForPage(page.index)"
         @click="page.index === currentPage ? undefined : goTo(page.index)"
       >
         {{ page.label }}
@@ -39,15 +39,15 @@
         &hellip;
       </span>
 
-      <a
+      <NuxtLink
         v-if="hasNext"
         class="relative inline-flex min-w-10 items-center px-2 py-2"
-        :href="hrefForPage(currentPage + 1)"
+        :to="toForPage(currentPage + 1)"
         @click="goTo(currentPage + 1)"
       >
         <span class="sr-only">Next</span>
         &gt;&gt;
-      </a>
+      </NuxtLink>
     </nav>
   </div>
 </template>
@@ -108,7 +108,7 @@ function goTo(page: number) {
   emit('update:current', Math.max(0, page));
 }
 
-function hrefForPage(page: number) {
+function toForPage(page: number) {
   const normalizedPage = Math.max(0, page);
   const query = { ...route.query } as Record<string, string | string[] | undefined>;
 
@@ -118,16 +118,9 @@ function hrefForPage(page: number) {
     delete query.page;
   }
 
-  const params = new URLSearchParams();
-  for (const [key, value] of Object.entries(query)) {
-    if (Array.isArray(value)) {
-      for (const item of value) params.append(key, item);
-    } else if (typeof value === 'string') {
-      params.set(key, value);
-    }
-  }
-
-  const queryString = params.toString();
-  return queryString ? `${route.path}?${queryString}` : route.path;
+  return {
+    path: route.path,
+    query,
+  };
 }
 </script>

--- a/playground/components/Drupal/DrupalViewsPagination.vue
+++ b/playground/components/Drupal/DrupalViewsPagination.vue
@@ -1,64 +1,108 @@
 <template>
   <div class="views-pager">
-    <nav
-      class="isolate inline-flex -space-x-px gap-1"
-      aria-label="Pagination"
-    >
-      <a
-        v-if="previousURL"
-        :href="previousURL"
-        class="relative inline-flex items-center px-2 py-2 text-sm min-w-10"
+    <nav class="isolate inline-flex -space-x-px gap-1" aria-label="Pagination">
+      <button
+        v-if="hasPrevious"
+        class="relative inline-flex min-w-10 items-center px-2 py-2 text-sm"
+        type="button"
+        @click="goTo(currentPage - 1)"
       >
         <span class="sr-only">Previous</span>
         &lt;&lt;
-      </a>
+      </button>
+
       <span
-        v-if="hellipLeft"
-        class="relative inline-flex items-center px-4 py-2 min-w-10"
-      >&hellip;</span>
-      <template v-for="n in totalPages">
-        <component
-          :is="n-1 == current ? 'span' : 'a'"
-          v-if="n-1 == current || (n-1 < current && n-1 > current - (maxLinks/2)-1) || (n-1 > current && n-1 < current + (maxLinks/2)+1)"
-          :key="n"
-          :href="'?page=' + (n-1)"
-          :class="{
-            'relative z-10 inline-flex items-center px-4 py-2 min-w-10': n-1 == current,
-            'relative inline-flex items-center px-4 py-2 min-w-10': n - 1 != current,
-          }"
-        >
-          {{ n }}
-        </component>
-      </template>
+        v-if="showLeftEllipsis"
+        class="relative inline-flex min-w-10 items-center px-4 py-2"
+      >
+        &hellip;
+      </span>
+
+      <component
+        :is="page.index === currentPage ? 'span' : 'button'"
+        v-for="page in pageLinks"
+        :key="page.index"
+        :class="{
+          'relative z-10 inline-flex min-w-10 items-center px-4 py-2': page.index === currentPage,
+          'relative inline-flex min-w-10 items-center px-4 py-2': page.index !== currentPage,
+        }"
+        :type="page.index === currentPage ? undefined : 'button'"
+        @click="page.index === currentPage ? undefined : goTo(page.index)"
+      >
+        {{ page.label }}
+      </component>
+
       <span
-        v-if="hellipRight"
-        class="relative inline-flex items-center min-w-10"
-      >&hellip;</span>
-      <a
-        v-if="nextURL"
-        :href="nextURL"
-        class="relative inline-flex items-center px-2 py-2 min-w-10"
+        v-if="showRightEllipsis"
+        class="relative inline-flex min-w-10 items-center px-4 py-2"
+      >
+        &hellip;
+      </span>
+
+      <button
+        v-if="hasNext"
+        class="relative inline-flex min-w-10 items-center px-2 py-2"
+        type="button"
+        @click="goTo(currentPage + 1)"
       >
         <span class="sr-only">Next</span>
         &gt;&gt;
-      </a>
+      </button>
     </nav>
   </div>
 </template>
 
 <script setup lang="ts">
-const props = withDefaults(defineProps<{
-  current: number
-  totalPages: number
-  maxLinks: number
-}>(), {
-  current: 0,
-  totalPages: 0,
-  maxLinks: 8,
-})
+const props = withDefaults(
+  defineProps<{
+    current: number,
+    totalPages: number,
+    maxLinks: number,
+  }>(),
+  {
+    current: 0,
+    totalPages: 0,
+    maxLinks: 8,
+  },
+);
 
-const previousURL = props.current > 0 ? `?page=${props.current - 1}` : null
-const nextURL = props.current + 1 < props.totalPages ? `?page=${props.current + 1}` : null
-const hellipLeft = props.current > props.maxLinks / 2 + 1
-const hellipRight = props.totalPages - props.current > props.maxLinks / 2
+const emit = defineEmits<{
+  'update:current': [value: number],
+}>();
+
+const currentPage = computed(() => Math.max(0, props.current));
+const totalPages = computed(() => Math.max(0, props.totalPages));
+const maxLinks = computed(() => Math.max(1, props.maxLinks));
+
+const startIndex = computed(() => {
+  if (totalPages.value <= maxLinks.value) return 0;
+
+  const half = Math.floor(maxLinks.value / 2);
+  const maxStart = Math.max(totalPages.value - maxLinks.value, 0);
+
+  return Math.min(Math.max(currentPage.value - half, 0), maxStart);
+});
+
+const endIndex = computed(() =>
+  Math.min(startIndex.value + maxLinks.value - 1, totalPages.value - 1),
+);
+
+const pageLinks = computed(() => {
+  const links: Array<{ index: number, label: number }> = [];
+
+  for (let index = startIndex.value; index <= endIndex.value; index += 1) {
+    links.push({ index, label: index + 1 });
+  }
+
+  return links;
+});
+
+const hasPrevious = computed(() => currentPage.value > 0);
+const hasNext = computed(() => currentPage.value + 1 < totalPages.value);
+const showLeftEllipsis = computed(() => startIndex.value > 0);
+const showRightEllipsis = computed(() => endIndex.value < totalPages.value - 1);
+
+function goTo(page: number) {
+  emit('update:current', Math.max(0, page));
+}
 </script>

--- a/playground/components/Drupal/DrupalViewsPagination.vue
+++ b/playground/components/Drupal/DrupalViewsPagination.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="views-pager">
     <nav class="isolate inline-flex -space-x-px gap-1" aria-label="Pagination">
-      <button
+      <a
         v-if="hasPrevious"
         class="relative inline-flex min-w-10 items-center px-2 py-2 text-sm"
-        type="button"
-        @click="goTo(currentPage - 1)"
+        :href="hrefForPage(currentPage - 1)"
+        @click="onPageClick($event, currentPage - 1)"
       >
         <span class="sr-only">Previous</span>
         &lt;&lt;
-      </button>
+      </a>
 
       <span
         v-if="showLeftEllipsis"
@@ -19,15 +19,15 @@
       </span>
 
       <component
-        :is="page.index === currentPage ? 'span' : 'button'"
+        :is="page.index === currentPage ? 'span' : 'a'"
         v-for="page in pageLinks"
         :key="page.index"
         :class="{
           'relative z-10 inline-flex min-w-10 items-center px-4 py-2': page.index === currentPage,
           'relative inline-flex min-w-10 items-center px-4 py-2': page.index !== currentPage,
         }"
-        :type="page.index === currentPage ? undefined : 'button'"
-        @click="page.index === currentPage ? undefined : goTo(page.index)"
+        :href="page.index === currentPage ? undefined : hrefForPage(page.index)"
+        @click="page.index === currentPage ? undefined : onPageClick($event, page.index)"
       >
         {{ page.label }}
       </component>
@@ -39,15 +39,15 @@
         &hellip;
       </span>
 
-      <button
+      <a
         v-if="hasNext"
         class="relative inline-flex min-w-10 items-center px-2 py-2"
-        type="button"
-        @click="goTo(currentPage + 1)"
+        :href="hrefForPage(currentPage + 1)"
+        @click="onPageClick($event, currentPage + 1)"
       >
         <span class="sr-only">Next</span>
         &gt;&gt;
-      </button>
+      </a>
     </nav>
   </div>
 </template>
@@ -70,9 +70,17 @@ const emit = defineEmits<{
   'update:current': [value: number],
 }>();
 
+const attrs = useAttrs();
+const route = useRoute();
+const router = useRouter();
+
 const currentPage = computed(() => Math.max(0, props.current));
 const totalPages = computed(() => Math.max(0, props.totalPages));
 const maxLinks = computed(() => Math.max(1, props.maxLinks));
+const hasUpdateListener = computed(() => {
+  const handler = attrs['onUpdate:current'];
+  return typeof handler === 'function' || Array.isArray(handler);
+});
 
 const startIndex = computed(() => {
   if (totalPages.value <= maxLinks.value) return 0;
@@ -104,5 +112,27 @@ const showRightEllipsis = computed(() => endIndex.value < totalPages.value - 1);
 
 function goTo(page: number) {
   emit('update:current', Math.max(0, page));
+}
+
+function hrefForPage(page: number) {
+  const normalizedPage = Math.max(0, page);
+  const query = { ...route.query } as Record<string, string | string[] | undefined>;
+
+  if (normalizedPage > 0) {
+    query.page = String(normalizedPage);
+  } else {
+    delete query.page;
+  }
+
+  return router.resolve({
+    path: route.path,
+    query,
+  }).href;
+}
+
+function onPageClick(event: MouseEvent, page: number) {
+  if (!hasUpdateListener.value) return;
+  event.preventDefault();
+  goTo(page);
 }
 </script>

--- a/playground/components/global/drupal-view--default.vue
+++ b/playground/components/global/drupal-view--default.vue
@@ -14,6 +14,7 @@
       v-if="pager.totalPages"
       :total-pages="pager.totalPages"
       :current="pager.current"
+      @update:current="onPageChange"
     />
     <div v-if="slots.footer" class="view-footer">
       <slot name="footer" />
@@ -45,5 +46,22 @@ const props = withDefaults(defineProps<{
   pager: () => ({}),
 });
 
+const route = useRoute();
+const router = useRouter();
 const slots = useSlots();
+
+function onPageChange(page: number) {
+  const query = { ...route.query } as Record<string, string | string[] | undefined>;
+
+  if (page > 0) {
+    query.page = String(page);
+  } else {
+    delete query.page;
+  }
+
+  void router.replace({
+    path: route.path,
+    query,
+  });
+}
 </script>

--- a/playground/composables/useDrupalCeViewControls.example.ts
+++ b/playground/composables/useDrupalCeViewControls.example.ts
@@ -1,0 +1,61 @@
+/**
+ * Example shape for a shared, headless view-controls composable.
+ *
+ * This is intentionally UI-agnostic and intended as reference for module-level APIs.
+ */
+export interface ViewControlsConfig {
+  path: string
+  viewId?: string
+  displayId?: string
+  parentUuid?: string
+}
+
+export function useDrupalCeViewControlsExample(_config: ViewControlsConfig) {
+  const rows = ref<unknown[]>([])
+  const pager = ref({ current: 0, totalPages: 1 })
+  const filters = ref<Record<string, string | string[]>>({})
+  const sorts = ref<Record<string, string>>({})
+  const noResults = ref('')
+  const isLoading = ref(false)
+  const error = ref('')
+
+  async function refresh() {
+    // 1) build query from filters/sorts/page
+    // 2) fetch data using Drupal CE API
+    // 3) find matching view node by viewId/displayId/parentUuid
+    // 4) update rows/pager/noResults
+  }
+
+  function setFilter(key: string, value: string | string[]) {
+    filters.value[key] = value
+  }
+
+  function setSort(key: string, value: string) {
+    sorts.value[key] = value
+  }
+
+  function setPage(page: number) {
+    pager.value.current = page
+  }
+
+  function reset() {
+    filters.value = {}
+    sorts.value = {}
+    pager.value.current = 0
+  }
+
+  return {
+    rows,
+    pager,
+    filters,
+    sorts,
+    noResults,
+    isLoading,
+    error,
+    refresh,
+    setFilter,
+    setSort,
+    setPage,
+    reset,
+  }
+}

--- a/test/e2e/errorhandling.test.ts
+++ b/test/e2e/errorhandling.test.ts
@@ -35,12 +35,12 @@ describe('Module error handling', async () => {
     // These would fail to render if the page data wasn't properly cached during SSR
     expect(html).toContain('Page not found')
   })
-  it('handles 500 statusCode', async () => {
-    const response = await fetch('/error500')
-    expect(response.status).toEqual(500)
-  })
   it('handles 404 statusCode', async () => {
     const { status } = await fetch('/error404')
     expect(status).toEqual(404)
+  })
+  it('handles 500 statusCode', async () => {
+    const response = await fetch('/error500')
+    expect(response.status).toEqual(500)
   })
 })

--- a/test/e2e/errorhandling.test.ts
+++ b/test/e2e/errorhandling.test.ts
@@ -3,6 +3,33 @@ import { describe, it, expect } from 'vitest'
 import { setup, fetch } from '@nuxt/test-utils/e2e'
 import { join } from 'node:path'
 
+const retryableSocketErrors = new Set(['ECONNREFUSED', 'UND_ERR_SOCKET'])
+
+function isRetryableFetchError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const maybeError = error as { code?: string, cause?: unknown }
+  if (typeof maybeError.code === 'string' && retryableSocketErrors.has(maybeError.code)) return true
+  if (!maybeError.cause || typeof maybeError.cause !== 'object') return false
+  const cause = maybeError.cause as { code?: string, cause?: unknown }
+  if (typeof cause.code === 'string' && retryableSocketErrors.has(cause.code)) return true
+  if (!cause.cause || typeof cause.cause !== 'object') return false
+  const nestedCause = cause.cause as { code?: string }
+  return typeof nestedCause.code === 'string' && retryableSocketErrors.has(nestedCause.code)
+}
+
+async function fetchWithRetry(url: string, attempts = 4, delayMs = 350) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await fetch(url)
+    }
+    catch (error) {
+      if (!isRetryableFetchError(error) || attempt === attempts) throw error
+      await new Promise(resolve => setTimeout(resolve, delayMs))
+    }
+  }
+  throw new Error(`Failed to fetch ${url} after ${attempts} attempts`)
+}
+
 describe('Module error handling', async () => {
   await setup({
     rootDir: join(fileURLToPath(import.meta.url), '../../../playground'),
@@ -10,14 +37,14 @@ describe('Module error handling', async () => {
     port: 3001,
   })
   it('renders Drupal error page', async () => {
-    const response = await fetch('/node/404')
+    const response = await fetchWithRetry('/node/404')
     expect(response.status).toEqual(404)
     // HTML returned from SSR page to contain
     // (same as what $fetch returns, but can't use $fetch because the promise rejects)
     expect(await response.text()).toContain('The requested page could not be found')
   })
   it('renders Drupal error page with proper hydration (no 502/503 errors)', async () => {
-    const response = await fetch('/node/404')
+    const response = await fetchWithRetry('/node/404')
     expect(response.status).toEqual(404)
     const html = await response.text()
 
@@ -36,11 +63,11 @@ describe('Module error handling', async () => {
     expect(html).toContain('Page not found')
   })
   it('handles 404 statusCode', async () => {
-    const { status } = await fetch('/error404')
+    const { status } = await fetchWithRetry('/error404')
     expect(status).toEqual(404)
   })
   it('handles 500 statusCode', async () => {
-    const response = await fetch('/error500')
+    const response = await fetchWithRetry('/error500')
     expect(response.status).toEqual(500)
   })
 })

--- a/test/e2e/errorhandling.test.ts
+++ b/test/e2e/errorhandling.test.ts
@@ -30,6 +30,29 @@ async function fetchWithRetry(url: string, attempts = 4, delayMs = 350) {
   throw new Error(`Failed to fetch ${url} after ${attempts} attempts`)
 }
 
+async function fetchExpectStatus(url: string, expectedStatus: number, attempts = 5, delayMs = 350) {
+  let lastResponse: Awaited<ReturnType<typeof fetch>> | undefined
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const response = await fetchWithRetry(url, 3, delayMs)
+    lastResponse = response
+
+    if (response.status === expectedStatus) {
+      return response
+    }
+
+    // During app startup in CI, Drupal proxy can briefly return gateway errors.
+    if ((response.status === 502 || response.status === 503) && attempt < attempts) {
+      await new Promise(resolve => setTimeout(resolve, delayMs))
+      continue
+    }
+
+    return response
+  }
+
+  return lastResponse as Awaited<ReturnType<typeof fetch>>
+}
+
 describe('Module error handling', async () => {
   await setup({
     rootDir: join(fileURLToPath(import.meta.url), '../../../playground'),
@@ -63,11 +86,11 @@ describe('Module error handling', async () => {
     expect(html).toContain('Page not found')
   })
   it('handles 404 statusCode', async () => {
-    const { status } = await fetchWithRetry('/error404')
+    const { status } = await fetchExpectStatus('/error404', 404)
     expect(status).toEqual(404)
   })
   it('handles 500 statusCode', async () => {
-    const response = await fetchWithRetry('/error500')
+    const response = await fetchExpectStatus('/error500', 500)
     expect(response.status).toEqual(500)
   })
 })


### PR DESCRIPTION
## Summary
- add headless, UI-agnostic view-controls guidance in playground/VIEW_CONTROLS.md
- add useDrupalCeViewControls example composable for filtering, sorting, and pagination state
- wire drupal-view--default pagination to route query updates
- update DrupalViewsPagination to use NuxtLink-based page navigation with update:current support
- harden test/e2e/errorhandling.test.ts against transient socket startup failures in CI

## Why
- provides a documented reference implementation teams can reuse without locking into a specific UI library
- keeps pagination URL-driven and shareable while preserving component-level update events
- reduces flaky CI failures caused by intermittent app-start timing issues during e2e fetch calls

## Scope
- playground/docs + pagination component + related e2e reliability improvements
- no API contract changes in the module runtime

## Validation
- CI e2e suite for this PR (Node 22)