### PR TITLE
improve: make default canvas component catch all canvas-* elements

### DIFF
--- a/playground/components/global/canvas--default.vue
+++ b/playground/components/global/canvas--default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="canvas-page">
+  <div class="canvas">
     <slot name="components" />
   </div>
 </template>


### PR DESCRIPTION
## Summary

- Renames `canvas-page--default.vue` → `canvas--default.vue` so it acts as a generic catch-all for any canvas-rendered element (not just `canvas-page` entities)
- Updates CSS class from `canvas-page` to `canvas`

With the canvas content template support in custom_elements ([#3587388](https://www.drupal.org/project/custom_elements/issues/3587388)), entities rendered via a Canvas ContentTemplate produce custom element tags like `<canvas-node-page-full>`. The `canvas--default.vue` fallback now handles all `canvas-*` prefixed elements, including both canvas pages and canvas-rendered content entities.

Related: drunomics/lupus-decoupled-nuxt-starter@cf4d5ef

🤖 Generated with [Claude Code](https://claude.com/claude-code)