### PR TITLE
feat: MCD-604: Render form #prefix / #suffix slots outside wrapper

### DIFF
--- a/playground/components/global/drupal-form--default.vue
+++ b/playground/components/global/drupal-form--default.vue
@@ -1,4 +1,7 @@
 <template>
+  <!-- #prefix / #suffix render outside <form> so sibling forms (e.g.
+       openid_connect's per-provider buttons) aren't nested. -->
+  <slot name="prefix" />
   <form
     :formId="formId"
     :method="method"
@@ -8,6 +11,7 @@
   >
     <slot />
   </form>
+  <slot name="suffix" />
 </template>
 
 <script setup lang="ts">
@@ -19,6 +23,8 @@ defineProps<{
 
 defineSlots<{
   default(): any
+  prefix(): any
+  suffix(): any
 }>()
 </script>
 

--- a/test/nuxt/drupalFormPrefixSuffixSlots.test.ts
+++ b/test/nuxt/drupalFormPrefixSuffixSlots.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment nuxt
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import DrupalFormDefault from '../../playground/components/global/drupal-form--default.vue'
+
+describe('drupal-form--default #prefix / #suffix slots', () => {
+  it('renders #prefix and #suffix outside the wrapper form', async () => {
+    const wrapper = await mountSuspended(DrupalFormDefault, {
+      props: {
+        formId: 'user_login_form',
+        attributes: {},
+        method: 'post',
+      },
+      slots: {
+        default: '<div class="default-content">default</div>',
+        prefix: '<div class="prefix-content">prefix</div>',
+        suffix: '<div class="suffix-content">suffix</div>',
+      },
+    })
+
+    const html = wrapper.html()
+    const formHtml = wrapper.find('form').html()
+
+    // Default slot lands inside the form.
+    expect(formHtml).toContain('default-content')
+
+    // Prefix and suffix render in the wrapper output but NOT inside the form
+    // (sibling forms in #prefix / #suffix would otherwise be nested).
+    expect(html).toContain('prefix-content')
+    expect(html).toContain('suffix-content')
+    expect(formHtml).not.toContain('prefix-content')
+    expect(formHtml).not.toContain('suffix-content')
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #479 (multi-`Set-Cookie` SSR fix). Updates the default `drupal-form` playground template to render `#prefix` / `#suffix` named slots **outside** the wrapper `<form>` element.

## Why

Backend support for this lands in [lupus_decoupled d.o 3586210](https://www.drupal.org/node/3586210) — that patch extracts a form's `#prefix` / `#suffix` render-array markup into dedicated `prefix` / `suffix` slots in the CE-API JSON response. Without this template change, those slots either drop or land inside the wrapper `<form>` — and in cases like `openid_connect` the prefix/suffix carries a *sibling* `<form>` element (one per provider), which would then be nested. Browsers don't support nested forms, so submissions break.

## Test plan

- New Vitest at `test/nuxt/drupalFormPrefixSuffixSlots.test.ts` mounts the component with `prefix` / `default` / `suffix` slots and asserts:
  - Default slot lands inside the form.
  - Prefix and suffix render in the wrapper output, but **not** inside the `<form>` element.

Verified end-to-end against a live local Drupal with `openid_connect` enabled — the user_login_form and the openid_connect_login_form render as sibling `<form>` elements, not nested. Detail in [MCD-604](https://drunomics.youtrack.cloud/issue/MCD-604).
