### PR TITLE
ci: MCD-1060 Run npm ci with npm 11 to accept bot-updated lockfiles.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
+      # Renovate and dependabot regenerate package-lock.json with npm 11;
+      # the npm 10 bundled with Node 22 rejects those lockfiles as out of
+      # sync, so `npm ci` needs npm 11 too.
+      - run: npm install -g npm@^11
       - run: npm ci
       - run: npx playwright install --with-deps
       - run: npm run dev:prepare


### PR DESCRIPTION
## Problem

Every recent renovate/dependabot PR fails CI at the `Run npm ci` step with *"package.json and package-lock.json are in sync"* errors (e.g. [run 27294386188](https://github.com/drunomics/nuxtjs-drupal-ce/actions/runs/27294386188), [run 27258407382](https://github.com/drunomics/nuxtjs-drupal-ce/actions/runs/27258407382)). All 21 CI failures since April fail at this same step — none are actual test failures.

Root cause: renovate and dependabot regenerate `package-lock.json` with **npm 11**, while the CI job runs the **npm 10** bundled with Node 22. npm 10's `npm ci` rejects npm-11-shaped lockfiles as out of sync ("Missing: … from lock file"). Locally with npm 11, `npm ci` passes on the same branches.

## Fix

Install npm 11 before `npm ci`. Node 22 stays the tested runtime (npm 11 supports Node ^20.17.0 || >=22.9.0).

## Notes

Drafted with Claude Code in the loki dev VM. Part of MCD-1060 (first of two PRs — the payload.path hydration fix follows separately).