### PR TITLE
feat: lazy useDrupalCe().loadLibrary() for on-demand Drupal JS libraries

### DIFF
--- a/playground/components/global/drupal-library--default.vue
+++ b/playground/components/global/drupal-library--default.vue
@@ -1,0 +1,58 @@
+<script lang="ts">
+import { defineComponent, onMounted, type PropType } from 'vue'
+import { useDrupalCe } from '../../../src/runtime/composables/useDrupalCe'
+
+/**
+ * A single JS file of a Drupal library, as emitted by the backend.
+ */
+interface DrupalLibraryJsFile {
+  /** Root-relative (e.g. `/core/misc/states.js?v=…`) or absolute URL. */
+  url: string
+  /** Optional attributes for the `<script>` tag (reserved). */
+  attributes?: Record<string, unknown>
+}
+
+/**
+ * Loads a Drupal JavaScript library in the decoupled frontend.
+ *
+ * The backend emits one `<drupal-library-*>` element per attached library
+ * (form #states, autocomplete, …), in dependency order, as siblings of the
+ * rendered markup, each carrying its resolved JS files. This is a thin consumer
+ * of `useDrupalCe().loadLibrary()`: the actual loader is lazy-loaded on first
+ * use. A specific library can be replaced with a native implementation by
+ * adding a component named after its tag, e.g. `DrupalLibraryCoreDrupalStates.vue`.
+ *
+ * Renderless: it emits no markup, it only triggers the load side-effect — hence
+ * `defineComponent` with a `() => null` render rather than `<script setup>`
+ * (which requires a template root and would emit a wrapper element).
+ */
+export default defineComponent({
+  props: {
+    /** The Drupal library name, e.g. `core/drupal.states`. */
+    library: {
+      type: String,
+      required: true,
+    },
+    /** JS files to load, in dependency order. */
+    js: {
+      type: Array as PropType<DrupalLibraryJsFile[]>,
+      default: () => [],
+    },
+    /** Merged drupalSettings (JSON string); present on the first element only. */
+    drupalSettings: {
+      type: String,
+      default: undefined,
+    },
+  },
+  setup(props) {
+    const { loadLibrary } = useDrupalCe()
+
+    onMounted(() => {
+      loadLibrary({ js: props.js, drupalSettings: props.drupalSettings })
+    })
+
+    // Renderless: emit no markup.
+    return () => null
+  },
+})
+</script>

--- a/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
+++ b/src/runtime/composables/useDrupalCe/drupalLibraryLoader.ts
@@ -1,0 +1,164 @@
+/**
+ * Lazy loader for Drupal JavaScript libraries in the decoupled frontend.
+ *
+ * This module is intentionally standalone (no Vue/Nuxt imports) and is only
+ * ever reached through a dynamic `import()` from `useDrupalCe().loadLibrary()`,
+ * so Vite splits it into its own chunk: neither the loader nor the Drupal JS it
+ * pulls in is shipped until a component actually loads a library.
+ *
+ * Loading is coordinated through a module-level queue so scripts execute in the
+ * order they are requested (dependencies before dependents, which the backend
+ * resolves) and `Drupal.attachBehaviors()` runs exactly once per batch.
+ */
+
+/** A single JS file of a Drupal library. */
+export interface DrupalLibraryJsFile {
+  /** Root-relative (e.g. `/core/misc/states.js?v=…`) or absolute URL. */
+  url: string
+  /** Optional attributes for the `<script>` tag (reserved). */
+  attributes?: Record<string, unknown>
+}
+
+/** A resolved Drupal library: its JS files (in load order) and merged settings. */
+export interface DrupalResolvedLibrary {
+  /** The library's JS files, in dependency order. */
+  js: DrupalLibraryJsFile[]
+  /** Merged drupalSettings as a JSON string (kept opaque so keys survive). */
+  drupalSettings?: string
+}
+
+/** URLs already loaded, so a library shared by several callers loads once. */
+const loadedScripts = new Set<string>()
+
+/** Serialises loading so scripts execute in request order across callers. */
+let queue: Promise<void> = Promise.resolve()
+
+/** Outstanding loads in the current batch; behaviours attach when it hits 0. */
+let pending = 0
+
+/**
+ * Resolves a library URL against the Drupal backend.
+ *
+ * @param url - Root-relative or absolute URL from the backend.
+ * @param baseUrl - The Drupal backend base URL.
+ * @returns A browser-loadable absolute URL.
+ */
+function absoluteUrl(url: string, baseUrl: string): string {
+  if (/^(https?:)?\/\//.test(url)) {
+    return url
+  }
+  return baseUrl.replace(/\/$/, '') + url
+}
+
+/**
+ * Injects a `<script>` for the given source, once.
+ *
+ * Already-loaded sources resolve immediately. A load error resolves (not
+ * rejects) with a warning so one missing asset does not abort a library or the
+ * behaviours: some Drupal "JS" is generated per request (e.g. locale
+ * translations) and legitimately 404s in a decoupled context.
+ *
+ * @param src - The absolute script URL to load.
+ * @returns A promise that settles when the script has loaded (or failed).
+ */
+function loadScript(src: string): Promise<void> {
+  if (loadedScripts.has(src) || document.querySelector(`script[data-drupal-library="${CSS.escape(src)}"]`)) {
+    loadedScripts.add(src)
+    return Promise.resolve()
+  }
+  return new Promise((resolve) => {
+    const el = document.createElement('script')
+    el.src = src
+    // Keep execution order deterministic even though the src is set eagerly.
+    el.async = false
+    el.dataset.drupalLibrary = src
+    el.onload = () => {
+      loadedScripts.add(src)
+      resolve()
+    }
+    el.onerror = () => {
+      console.warn(`[drupal-library] skipped, failed to load ${src}`)
+      resolve()
+    }
+    document.head.appendChild(el)
+  })
+}
+
+/**
+ * Type guard for a plain (non-array) object.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Recursively deep-merges `source` into `target`, mutating `target`.
+ */
+function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {
+  for (const key of Object.keys(source)) {
+    const next = source[key]
+    if (isPlainObject(next) && isPlainObject(target[key])) {
+      deepMerge(target[key] as Record<string, unknown>, next)
+    }
+    else {
+      target[key] = next
+    }
+  }
+  return target
+}
+
+/**
+ * Runs Drupal.attachBehaviors on the document, if Drupal has loaded.
+ *
+ * Safe to call repeatedly: Drupal's `once()` prevents re-processing.
+ */
+function attachBehaviors(): void {
+  const drupal = (window as unknown as { Drupal?: { attachBehaviors?: (el: Element, settings?: unknown) => void } }).Drupal
+  const settings = (window as unknown as { drupalSettings?: unknown }).drupalSettings
+  drupal?.attachBehaviors?.(document.body, settings)
+}
+
+/**
+ * Loads a resolved Drupal library, then attaches behaviours once the batch is
+ * done.
+ *
+ * `drupalSettings` (if any) is merged into `window.drupalSettings` synchronously
+ * before any script runs — Drupal core JS expects it to exist, and a decoupled
+ * page has no settings-json `<script>` for `drupalSettingsLoader.js` to read.
+ * Files are appended to the shared queue so they load after earlier requests;
+ * when the queue drains, behaviours attach once.
+ *
+ * @param library - The resolved library (JS files + optional drupalSettings).
+ * @param baseUrl - The Drupal backend base URL for resolving root-relative URLs.
+ * @returns A promise that settles once this library's files have loaded.
+ */
+export function loadDrupalLibrary(library: DrupalResolvedLibrary, baseUrl: string): Promise<void> {
+  if (library.drupalSettings) {
+    try {
+      const win = window as unknown as { drupalSettings?: Record<string, unknown> }
+      win.drupalSettings = deepMerge(win.drupalSettings ?? {}, JSON.parse(library.drupalSettings))
+    }
+    catch (error) {
+      console.error('[drupal-library] invalid drupalSettings', error)
+    }
+  }
+
+  const urls = (library.js ?? []).map(file => absoluteUrl(file.url, baseUrl))
+
+  pending++
+  const done = queue
+    .then(async () => {
+      for (const url of urls) {
+        await loadScript(url)
+      }
+    })
+    .catch(error => console.error(error))
+    .finally(() => {
+      pending--
+      if (pending === 0) {
+        attachBehaviors()
+      }
+    })
+  queue = done
+  return done
+}

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -663,32 +663,27 @@ export const useDrupalCe = () => {
   }
 
   /**
-   * Lazily loads a Drupal JS library in the browser and runs its behaviours.
+   * Lazily loads a resolved Drupal JS library in the browser and runs its
+   * behaviours.
    *
    * The heavy loader (script queue, drupalSettings seeding, attachBehaviors)
    * lives in a separate module and is dynamically imported here, so it — and
-   * the Drupal JS it pulls in — is only fetched the first time a component
-   * calls loadLibrary(). Use this from custom components to lazy-load a Drupal
-   * behaviour (form #states, autocomplete, …) exactly when it is needed.
+   * the Drupal JS it pulls in — is only fetched the first time loadLibrary() is
+   * called. The library is already resolved by the backend, which emits its JS
+   * files (in dependency order) and merged drupalSettings on the corresponding
+   * <drupal-library-*> custom element; this just loads them.
    *
-   * Pass a resolved library ({ js, drupalSettings }, as the backend emits on a
-   * <drupal-library-*> element) to load it directly, or a Drupal library name
-   * (e.g. 'core/drupal.states') to have the backend resolve it first — the
-   * latter needs the companion `/drupal-library/{name}` endpoint.
-   *
-   * @param library A resolved library object or a Drupal library name.
+   * @param library The resolved library ({ js, drupalSettings }) from the
+   *   backend-generated <drupal-library-*> element.
    * @returns Promise settling once the library's JS has loaded (client-side);
    *   resolves immediately on the server.
    */
-  const loadLibrary = async (library: DrupalResolvedLibrary | string): Promise<void> => {
+  const loadLibrary = async (library: DrupalResolvedLibrary): Promise<void> => {
     if (import.meta.server) {
       return
     }
     const { loadDrupalLibrary } = await (drupalLibraryLoaderPromise ??= import('./drupalLibraryLoader'))
-    const resolved = typeof library === 'string'
-      ? await $fetch<DrupalResolvedLibrary>(`${getDrupalBaseUrl()}/drupal-library/${encodeURIComponent(library)}`)
-      : library
-    await loadDrupalLibrary(resolved, getDrupalBaseUrl())
+    await loadDrupalLibrary(library, getDrupalBaseUrl())
   }
 
   return {

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -3,6 +3,7 @@ import { appendResponseHeader } from 'h3'
 import type { $Fetch, NitroFetchRequest } from 'nitropack'
 import { type Ref, type ComputedRef, type Component, type VNode, Fragment } from 'vue'
 import { getDrupalBaseUrl, getMenuBaseUrl, headersToRecord } from './server'
+import type { DrupalResolvedLibrary } from './drupalLibraryLoader'
 import type { UseFetchOptions, AsyncData } from '#app'
 import { callWithNuxt } from '#app'
 import { useRuntimeConfig, useState, useFetch, navigateTo, createError, h, resolveComponent, setResponseStatus, useNuxtApp, useRequestHeaders, ref, unref, watch, useRequestEvent, computed, useHead, defineComponent, toRef, useRoute, useRouter, useSlots } from '#imports'
@@ -654,9 +655,39 @@ export const useDrupalCe = () => {
     })
   }
 
+  /**
+   * Lazily loads a Drupal JS library in the browser and runs its behaviours.
+   *
+   * The heavy loader (script queue, drupalSettings seeding, attachBehaviors)
+   * lives in a separate module and is dynamically imported here, so it — and
+   * the Drupal JS it pulls in — is only fetched the first time a component
+   * calls loadLibrary(). Use this from custom components to lazy-load a Drupal
+   * behaviour (form #states, autocomplete, …) exactly when it is needed.
+   *
+   * Pass a resolved library ({ js, drupalSettings }, as the backend emits on a
+   * <drupal-library-*> element) to load it directly, or a Drupal library name
+   * (e.g. 'core/drupal.states') to have the backend resolve it first — the
+   * latter needs the companion `/drupal-library/{name}` endpoint.
+   *
+   * @param library A resolved library object or a Drupal library name.
+   * @returns Promise settling once the library's JS has loaded (client-side);
+   *   resolves immediately on the server.
+   */
+  const loadLibrary = async (library: DrupalResolvedLibrary | string): Promise<void> => {
+    if (import.meta.server) {
+      return
+    }
+    const { loadDrupalLibrary } = await import('./drupalLibraryLoader')
+    const resolved = typeof library === 'string'
+      ? await $fetch<DrupalResolvedLibrary>(`${getDrupalBaseUrl()}/drupal-library/${encodeURIComponent(library)}`)
+      : library
+    await loadDrupalLibrary(resolved, getDrupalBaseUrl())
+  }
+
   return {
     $ceApi,
     useCeApi,
+    loadLibrary,
     fetchPage,
     fetchMenu,
     getMessages,

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -9,6 +9,13 @@ import { callWithNuxt } from '#app'
 import { useRuntimeConfig, useState, useFetch, navigateTo, createError, h, resolveComponent, setResponseStatus, useNuxtApp, useRequestHeaders, ref, unref, watch, useRequestEvent, computed, useHead, defineComponent, toRef, useRoute, useRouter, useSlots } from '#imports'
 import type { DrupalCePage, DrupalCeApiResponse } from '../../types'
 
+// Cache the dynamic import of the library loader in a single module-level
+// promise. All loadLibrary() callers await the *same* promise, so their
+// continuations run in strict call order — which keeps libraries enqueued in
+// dependency order even when several <drupal-library-*> elements call it in the
+// same tick. (Per-call `import()` can resolve out of order under Vite dev.)
+let drupalLibraryLoaderPromise: Promise<typeof import('./drupalLibraryLoader')> | undefined
+
 export const useDrupalCe = () => {
   const config = useRuntimeConfig().public.drupalCe
   const privateConfig = import.meta.server && useRuntimeConfig().drupalCe
@@ -677,7 +684,7 @@ export const useDrupalCe = () => {
     if (import.meta.server) {
       return
     }
-    const { loadDrupalLibrary } = await import('./drupalLibraryLoader')
+    const { loadDrupalLibrary } = await (drupalLibraryLoaderPromise ??= import('./drupalLibraryLoader'))
     const resolved = typeof library === 'string'
       ? await $fetch<DrupalResolvedLibrary>(`${getDrupalBaseUrl()}/drupal-library/${encodeURIComponent(library)}`)
       : library

--- a/test/nuxt/drupal-library--default.test.ts
+++ b/test/nuxt/drupal-library--default.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment nuxt
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { flushPromises } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { useDrupalCe } from '../../src/runtime/composables/useDrupalCe'
+import DrupalLibraryDefault from '../../playground/components/global/drupal-library--default.vue'
+
+// Mock the actual loader so the component test stays DOM-side-effect free; the
+// loader's own behaviour is covered by drupalLibraryLoader.test.ts.
+const { loadDrupalLibrary } = vi.hoisted(() => ({ loadDrupalLibrary: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('../../src/runtime/composables/useDrupalCe/drupalLibraryLoader', () => ({ loadDrupalLibrary }))
+
+describe('drupal-library--default custom element', () => {
+  beforeEach(() => loadDrupalLibrary.mockClear())
+
+  const data = {
+    element: 'drupal-library-core-drupal-states',
+    library: 'core/drupal.states',
+    js: [{ url: '/core/misc/states.js?v=1' }],
+    drupalSettings: '{"my_module":{"some_key":"value"}}',
+  }
+
+  const createComponent = (d: Record<string, unknown> = data) => defineComponent({
+    components: { 'drupal-library-core-drupal-states': DrupalLibraryDefault },
+    setup() {
+      const { renderCustomElements } = useDrupalCe()
+      return { component: renderCustomElements(d) }
+    },
+    template: '<component :is="component" />',
+  })
+
+  it('is renderless — emits no markup', async () => {
+    const wrapper = await mountSuspended(createComponent())
+    // Only a comment placeholder for the null render, no elements.
+    expect(wrapper.html().replace(/<!--.*?-->/gs, '').trim()).toBe('')
+  })
+
+  it('loads the resolved library on mount', async () => {
+    await mountSuspended(createComponent())
+    await flushPromises()
+    expect(loadDrupalLibrary).toHaveBeenCalledTimes(1)
+    expect(loadDrupalLibrary.mock.calls[0]![0]).toEqual({
+      js: data.js,
+      drupalSettings: data.drupalSettings,
+    })
+  })
+})

--- a/test/nuxt/drupalLibraryLoader.test.ts
+++ b/test/nuxt/drupalLibraryLoader.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment nuxt
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+type LoaderModule = typeof import('../../src/runtime/composables/useDrupalCe/drupalLibraryLoader')
+
+/**
+ * Tests the standalone Drupal library loader. Script `<script>` tags are mocked
+ * to "load" immediately (there is no real network), so the assertions cover the
+ * loader's own behaviour: URL resolution, insertion order, dedup, drupalSettings
+ * seeding and the run-once attachBehaviors barrier.
+ */
+describe('drupalLibraryLoader', () => {
+  let loadDrupalLibrary: LoaderModule['loadDrupalLibrary']
+  let injected: HTMLScriptElement[]
+  let attachBehaviors: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    // Fresh module per test so the module-level queue/loaded-set reset.
+    vi.resetModules()
+    ;({ loadDrupalLibrary } = await import('../../src/runtime/composables/useDrupalCe/drupalLibraryLoader'))
+
+    injected = []
+    attachBehaviors = vi.fn()
+    ;(window as unknown as { Drupal?: unknown }).Drupal = { attachBehaviors }
+    ;(window as unknown as { drupalSettings?: unknown }).drupalSettings = undefined
+    if (!globalThis.CSS) {
+      globalThis.CSS = { escape: (s: string) => s } as unknown as typeof CSS
+    }
+
+    // Mock script insertion: record it and fire onload on the next microtask.
+    vi.spyOn(document.head, 'appendChild').mockImplementation(((el: HTMLScriptElement) => {
+      injected.push(el)
+      queueMicrotask(() => el.onload?.(new Event('load')))
+      return el
+    }) as typeof document.head.appendChild)
+  })
+
+  it('injects a library JS in order, absolute, async=false, tagged', async () => {
+    await loadDrupalLibrary(
+      { js: [{ url: '/core/misc/jquery.js?v=1' }, { url: '/core/misc/drupal.js?v=1' }] },
+      'http://backend',
+    )
+    expect(injected.map(s => s.src)).toEqual([
+      'http://backend/core/misc/jquery.js?v=1',
+      'http://backend/core/misc/drupal.js?v=1',
+    ])
+    expect(injected.every(s => s.async === false)).toBe(true)
+    expect(injected[0]!.dataset.drupalLibrary).toBe('http://backend/core/misc/jquery.js?v=1')
+    expect(attachBehaviors).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes absolute and protocol-relative URLs through untouched', async () => {
+    await loadDrupalLibrary({ js: [{ url: 'https://cdn.example/x.js' }] }, 'http://backend')
+    expect(injected.map(s => s.src)).toEqual(['https://cdn.example/x.js'])
+  })
+
+  it('loads each URL only once across calls (dedup)', async () => {
+    await loadDrupalLibrary({ js: [{ url: '/a.js' }] }, 'http://backend')
+    await loadDrupalLibrary({ js: [{ url: '/a.js' }, { url: '/b.js' }] }, 'http://backend')
+    expect(injected.map(s => s.src)).toEqual(['http://backend/a.js', 'http://backend/b.js'])
+  })
+
+  it('keeps dependency order across separate calls', async () => {
+    // Two libraries queued in the same tick — jQuery before the dependent one.
+    const first = loadDrupalLibrary({ js: [{ url: '/jquery.js' }] }, 'http://backend')
+    const second = loadDrupalLibrary({ js: [{ url: '/states.js' }] }, 'http://backend')
+    await Promise.all([first, second])
+    expect(injected.map(s => s.src)).toEqual(['http://backend/jquery.js', 'http://backend/states.js'])
+  })
+
+  it('seeds window.drupalSettings from the JSON string before loading', async () => {
+    await loadDrupalLibrary(
+      { js: [{ url: '/a.js' }], drupalSettings: '{"my_module":{"some_key":"value"}}' },
+      'http://backend',
+    )
+    expect((window as unknown as { drupalSettings: Record<string, unknown> }).drupalSettings)
+      .toEqual({ my_module: { some_key: 'value' } })
+  })
+})


### PR DESCRIPTION
Expose a **`useDrupalCe().loadLibrary()`** API so a component can lazily load a Drupal JS library (form `#states`, autocomplete, …).

## Design
The heavy loader — ordered script queue + dedup, `drupalSettings` seeding, run-once `Drupal.attachBehaviors()` — lives in its own module (`drupalLibraryLoader.ts`) reached via a **dynamic `import()`** from the composable, so the loader **and the Drupal JS it pulls in** are split into a separate chunk fetched only on first `loadLibrary()` call — nothing ships in the main bundle for pages that never touch a Drupal library.

`loadLibrary(library)` takes the **backend-resolved** library `{ js, drupalSettings }` — the shape the backend emits (JS files in dependency order + merged settings) on a `<drupal-library-*>` custom element. The frontend just loads it; there is no name→assets resolution on the client. Server-side it's a no-op.

The loader `import()` is cached in a single module-level promise so all callers await the same promise and enqueue in strict call order — otherwise per-call `import()` can resolve out of order (Vite dev) and scramble the load order.

## Context
Foundation for decoupled webform conditions — drunomics YouTrack MCD-605 / MCD-607. The backend that generates the `<drupal-library-*>` elements lives in the custom_elements module (drupal.org MR pending).

---
Drafted with Claude Code from the loki dev VM.