### PR TITLE
fix: MCD-1227 Preserve active query filters in views pager page links.

### DIFF
--- a/playground/components/Drupal/DrupalViewsPagination.vue
+++ b/playground/components/Drupal/DrupalViewsPagination.vue
@@ -21,7 +21,8 @@
           :is="n-1 == current ? 'span' : 'a'"
           v-if="n-1 == current || (n-1 < current && n-1 > current - (maxLinks/2)-1) || (n-1 > current && n-1 < current + (maxLinks/2)+1)"
           :key="n"
-          :href="'?page=' + (n-1)"
+          :href="pageHref(n-1)"
+          :aria-current="n-1 == current ? 'page' : undefined"
           :class="{
             'relative z-10 inline-flex items-center px-4 py-2 min-w-10': n-1 == current,
             'relative inline-flex items-center px-4 py-2 min-w-10': n - 1 != current,
@@ -57,8 +58,30 @@ const props = withDefaults(defineProps<{
   maxLinks: 8,
 })
 
-const previousURL = props.current > 0 ? `?page=${props.current - 1}` : null
-const nextURL = props.current + 1 < props.totalPages ? `?page=${props.current + 1}` : null
+const route = useRoute()
+
+// Build a page link by merging `page` into the current route query so active
+// exposed-filter params (?text=, ?kategorie=, …) are preserved when paging.
+// Page 0 drops the param entirely for a clean canonical first-page URL.
+// The href stays query-only (relative) so it resolves against the current path.
+function pageHref(page: number): string {
+  const query: Record<string, string> = {}
+  Object.entries(route.query).forEach(([key, value]) => {
+    if (value == null || value === '') return
+    query[key] = Array.isArray(value) ? String(value[value.length - 1]) : String(value)
+  })
+  if (page > 0) {
+    query.page = String(page)
+  }
+  else {
+    delete query.page
+  }
+  const qs = new URLSearchParams(query).toString()
+  return qs ? `?${qs}` : '?'
+}
+
+const previousURL = props.current > 0 ? pageHref(props.current - 1) : null
+const nextURL = props.current + 1 < props.totalPages ? pageHref(props.current + 1) : null
 const hellipLeft = props.current > props.maxLinks / 2 + 1
 const hellipRight = props.totalPages - props.current > props.maxLinks / 2
 </script>

--- a/test/nuxt/drupalViewsPagination.test.ts
+++ b/test/nuxt/drupalViewsPagination.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment nuxt
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineComponent } from 'vue'
+import { useDrupalCe } from '../../src/runtime/composables/useDrupalCe'
+import DrupalView from '../../playground/components/global/drupal-view--default.vue'
+import DrupalViewsPagination from '../../playground/components/Drupal/DrupalViewsPagination.vue'
+
+describe('drupal-view pagination links', () => {
+  const createViewComponent = (pager, slots = {}) => defineComponent({
+    components: { 'drupal-view': DrupalView, 'drupal-views-pagination': DrupalViewsPagination },
+    setup() {
+      const { renderCustomElements } = useDrupalCe()
+      return { component: renderCustomElements({
+        element: 'drupal-view',
+        props: { title: 'Test view', viewId: 'test', displayId: 'page_1', pager },
+        slots,
+      }) }
+    },
+    template: '<component :is="component" />',
+  })
+
+  it('renders bare ?page=N links when no filters are active', async () => {
+    const wrapper = await mountSuspended(createViewComponent({ totalPages: 3, current: 0 }), {
+      route: '/listing',
+    })
+    const hrefs = wrapper.findAll('.views-pager a').map(a => a.attributes('href'))
+    // Page 2 and 3 links carry only the page param; the current first page is a
+    // <span>, not a link.
+    expect(hrefs).toContain('?page=1')
+    expect(hrefs).toContain('?page=2')
+  })
+
+  it('preserves active exposed-filter query params in page links', async () => {
+    const wrapper = await mountSuspended(createViewComponent({ totalPages: 3, current: 0 }), {
+      route: '/listing?text=foo&kategorie=5',
+    })
+    const hrefs = wrapper.findAll('.views-pager a').map(a => a.attributes('href'))
+    // Every page link keeps text= and kategorie= and appends page=.
+    expect(hrefs).toContain('?text=foo&kategorie=5&page=1')
+    expect(hrefs).toContain('?text=foo&kategorie=5&page=2')
+    // No link drops the filters back to a bare ?page=N.
+    expect(hrefs).not.toContain('?page=1')
+  })
+
+  it('drops the page param on the first-page link and marks the current page', async () => {
+    // On page 1 (current=1), the link back to page 0 must carry filters but no
+    // page param, and the active page must expose aria-current.
+    const wrapper = await mountSuspended(createViewComponent({ totalPages: 3, current: 1 }), {
+      route: '/listing?text=foo',
+    })
+    const hrefs = wrapper.findAll('.views-pager a').map(a => a.attributes('href'))
+    expect(hrefs).toContain('?text=foo')
+    expect(hrefs).not.toContain('?text=foo&page=0')
+    expect(wrapper.find('.views-pager [aria-current="page"]').text()).toBe('2')
+  })
+})


### PR DESCRIPTION
## Problem

`DrupalViewsPagination` (playground component that projects copy) builds page links as bare `?page=N`, **discarding any other active query params** — exposed View filters, search terms, etc. On a decoupled View that exposes filters via GET (e.g. a listing with `?text=` fulltext or `?kategorie=<tid>` taxonomy), paging to page 2 resets the filters and returns the unfiltered result set.

## Fix

Merge `page` into the current route query (via `useRoute()`) instead of composing a bare `?page=N`. The href stays **query-only** so it resolves against the current path — this keeps existing selectors like `a[href="?page=1"]` working. Page 0 drops the `page` param for a clean canonical first-page URL, and the active page carries `aria-current="page"`.

## Test coverage

Adds `test/nuxt/drupalViewsPagination.test.ts`: mounts the `drupal-view` custom element with a pager under a filtered route and asserts the page links keep the filters (`?text=foo&kategorie=5&page=1`), that page 0 drops the param, and that the active page exposes `aria-current`. Full nuxt suite green (63 tests).

## Context

Split off from [MCD-1227](https://drunomics.youtrack.cloud/issue/MCD-1227) / MOP-535. kickstart ships its own i18n copy of this component with the same fix ([kickstart PR #1258](https://github.com/drunomics/lupus-nuxt3-kickstart/pull/1258)); this lands the behaviour in the upstream source so downstream copies stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)