### PR TITLE
test: MCD-1227 Run nested test/nuxt component tests and fix stale expectations.

### DIFF
--- a/test/nuxt/components/drupal-form--default.test.ts
+++ b/test/nuxt/components/drupal-form--default.test.ts
@@ -8,13 +8,17 @@ import DrupalFormDefault from '../../../playground/components/global/drupal-form
 describe('drupal-form--default custom element', () => {
   const formData = {
     element: 'drupal-form',
-    formId: 'user_login_form',
-    attributes: {
-      class: ['user-login-form'],
-      dataDrupalSelector: 'user-login-form'
+    props: {
+      formId: 'user_login_form',
+      attributes: {
+        class: ['user-login-form'],
+        dataDrupalSelector: 'user-login-form'
+      },
+      method: 'post',
     },
-    method: 'post',
-    content: '<div>Some form content html.</div>'
+    slots: {
+      default: '<div>Some form content html.</div>'
+    }
   }
 
   const createFormComponent = (data = formData) => defineComponent({

--- a/test/nuxt/components/drupal-markup.test.ts
+++ b/test/nuxt/components/drupal-markup.test.ts
@@ -61,8 +61,9 @@ describe('drupal-markup custom element', () => {
       })
       const wrapper = await mountSuspended(TestComponent)
       expect(wrapper.html()).toContain('<p>Slotted <b>content</b></p>')
-      // drupal-markup should not add a wrapping element when only slot is used
-      expect(wrapper.html()).toEqual('<p>Slotted <b>content</b></p>')
+      // drupal-markup should not add a wrapping element when only slot is used.
+      // (Vue emits a <!--v-if--> placeholder for the unused content div.)
+      expect(wrapper.html()).not.toContain('<div')
     })
 
     it('renders nested elements via slot', async () => {
@@ -157,7 +158,9 @@ describe('drupal-markup custom element', () => {
       })
       const wrapper = await mountSuspended(component)
       expect(wrapper.html()).toContain('<p>Only slot</p>')
-      expect(wrapper.html()).not.toContain('display: contents')
+      // The component's own content div is skipped when the content prop is undefined;
+      // Vue emits a <!--v-if--> placeholder in its place.
+      expect(wrapper.html()).toContain('<!--v-if-->')
     })
 
     it('renders only content prop when slot is empty', async () => {

--- a/test/nuxt/components/field--default.test.ts
+++ b/test/nuxt/components/field--default.test.ts
@@ -12,7 +12,7 @@ describe('field--default custom element', () => {
       const { renderCustomElements } = useDrupalCe()
       return { component: renderCustomElements({
         element: 'field-image',
-        content,
+        slots: { default: content },
       }) }
     },
     template: '<component :is="component" />',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       await defineVitestProject({
         test: {
           name: 'nuxt',
-          include: ['test/nuxt/*.{test,spec}.ts'],
+          include: ['test/nuxt/**/*.{test,spec}.ts'],
           environment: 'nuxt',
           environmentOptions: {
             port: 3001,


### PR DESCRIPTION
Follow-up to #505 (MCD-1227), requested by @fago: the `test/nuxt/components/*.test.ts` files never ran because the vitest `nuxt` project include (`test/nuxt/*.{test,spec}.ts`) is non-recursive. Because they never executed, they had drifted from actual component behaviour.

## Changes

- **`vitest.config.ts`** — recurse the `nuxt` project glob: `test/nuxt/*.{test,spec}.ts` → `test/nuxt/**/*.{test,spec}.ts`. The five `components/` test files now execute.
- Fixed the four now-failing expectations. All were **test-side**; the components are unchanged and correct:
  - **`field--default` / `drupal-form--default`** — passed content via a top-level `content` key. In the explicit custom-element format only `element`/`props`/`slots` are recognised; a stray `content` key falls back to legacy handling and, for a component without a `content` prop, becomes a fall-through DOM attribute (`<div content="…">`). Fixed to pass content via `slots.default` (and moved the form's `formId`/`attributes`/`method` under `props`).
  - **`drupal-markup`** — a **string** slot is itself rendered as a nested `drupal-markup`, which legitimately wraps in `display: contents`; and Vue emits a `<!--v-if-->` placeholder for the unused content `v-if` div. Replaced two brittle exact-string matches with assertions for the placeholder / absence of a wrapping `<div>`.

## Verification

- `npm run test` → `nuxt` project: **81 passed (14 files, was 11)**. The five `components/` files now run and pass.
- Changed files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)