### PR TITLE
fix: MCD-1270 Keep redirect payloads in the page cache so SPA repeat visits follow CE-API redirects.

### DIFF
--- a/playground/server/routes/ce-api/api/menu_items/main.ts
+++ b/playground/server/routes/ce-api/api/menu_items/main.ts
@@ -32,6 +32,22 @@ export default defineEventHandler(() => [
     options: [] 
   },
   {
+    key: 'redirecting-page',
+    title: 'Redirecting page',
+    description: null,
+    uri: 'redirect-to-3',
+    alias: 'redirect-to-3',
+    external: false,
+    absolute: 'https:\/\/8080-drunomics-lupusdecouple-fd0ilwlpax7.ws-eu84.gitpod.io\/redirect-to-3',
+    relative: '\/redirect-to-3',
+    existing: true,
+    weight: '0',
+    expanded: false,
+    enabled: true,
+    uuid: 'redirecting-page',
+    options: []
+  },
+  {
     key: 'layout-builder-demo',
     title: 'Layout',
     description: null,

--- a/playground/server/routes/ce-api/redirect-to-3.ts
+++ b/playground/server/routes/ce-api/redirect-to-3.ts
@@ -1,0 +1,10 @@
+export default defineEventHandler(() => {
+  return {
+    redirect: {
+      external: false,
+      statusCode: 302,
+      url: '/node/3',
+    },
+    messages: [],
+  }
+})

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -253,11 +253,15 @@ export const useDrupalCe = () => {
 
     // Handle redirect
     if (pageRef.value?.redirect) {
+      const redirect = pageRef.value.redirect
       await callWithNuxt(nuxtApp, navigateTo, [
-        pageRef.value.redirect.url,
-        { external: pageRef.value.redirect.external, redirectCode: pageRef.value.redirect.statusCode, replace: true },
+        redirect.url,
+        { external: redirect.external, redirectCode: redirect.statusCode, replace: true },
       ])
-      pageRef.value = createEmptyPage()
+      // Return an empty page without touching pageRef: pageRef is bound to
+      // the useFetch payload cache entry, overwriting it would poison the
+      // cache with an empty page and drop the redirect on repeat visits.
+      pageRef = ref(createEmptyPage())
     }
     // Handle error
     else if (error) {

--- a/test/e2e/redirect.test.ts
+++ b/test/e2e/redirect.test.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
-import { setup, $fetch } from '@nuxt/test-utils/e2e'
+import { setup, $fetch, url, createPage } from '@nuxt/test-utils/e2e'
 import { join } from 'node:path'
 
 describe('Module redirects work', async () => {
@@ -8,10 +8,51 @@ describe('Module redirects work', async () => {
     rootDir: join(fileURLToPath(import.meta.url), '../../../playground'),
     configFile: 'nuxt.config4test',
     port: 3001,
+    browser: true,
   })
+
   it('redirect to /node/1 works', async () => {
     const html = await $fetch('/redirect')
     await new Promise(resolve => setTimeout(resolve, 3000))
     expect(html).toContain('Node: Test page')
+  })
+
+  /**
+   * A CE-API redirect payload arriving during SPA (client-side) navigation
+   * must re-target the visible route: the URL must end up on the redirect
+   * target and the target page must mount.
+   *
+   * The repeat visit is the critical case: the payload cache entry for the
+   * redirect source must retain the redirect payload, so the redirect is
+   * followed again when fetchPage() serves the path from the cache. If
+   * fetchPage() overwrites the entry (e.g. with an empty page), repeat
+   * visits strand on the source URL with the previous page visible.
+   */
+  it('redirect is followed on SPA navigation, including repeat visits', { timeout: 60000 }, async () => {
+    const page = await createPage()
+    await page.goto(url('/node/1'), { waitUntil: 'hydration' })
+    expect(await page.evaluate(() => document.body.textContent)).toContain('Test page')
+
+    // First SPA visit: CE-API answers /redirect-to-3 with a redirect
+    // payload to /node/3 (async fetch).
+    await page.click('a[href="/redirect-to-3"]')
+    await page.waitForURL('**/node/3', { timeout: 10000 })
+    expect(page.url()).toBe(url('/node/3'))
+    expect(await page.evaluate(() => document.body.textContent)).toContain('Another page')
+
+    // Navigate back to the start page (/node/3 uses the bare "clear"
+    // layout without the main menu, so use history navigation).
+    await page.goBack()
+    await page.waitForURL('**/node/1', { timeout: 10000 })
+    expect(await page.evaluate(() => document.body.textContent)).toContain('Test page')
+
+    // Second SPA visit: the redirect payload is served from the client-side
+    // cache (synchronous resolution) — the redirect must still be followed.
+    await page.click('a[href="/redirect-to-3"]')
+    await page.waitForURL('**/node/3', { timeout: 10000 })
+    expect(page.url()).toBe(url('/node/3'))
+    expect(await page.evaluate(() => document.body.textContent)).toContain('Another page')
+
+    await page.close()
   })
 })


### PR DESCRIPTION
## Summary

CE-API redirects were not followed on repeat SPA visits to a redirected path: the URL stayed on the source path and the previously mounted page remained visible (MOP-571, observed on beta.vegan.at `/newsletter` → `/inhalt/newsletter-anmeldung`).

## Root cause

Not a navigation race (the imperative `navigateTo()` in `fetchPage()` wins fine, first visits always work): after handling a redirect, `fetchPage()` did `pageRef.value = createEmptyPage()`. `pageRef` is the `useFetch` data ref bound to the payload cache entry of the redirect source path, so this **overwrote the cached redirect payload with an empty page**. On every subsequent SPA visit to the path, `fetchPage()` served the poisoned cache entry — no `redirect` key, no navigation, empty page under the source URL, previous page effectively still visible.

Reproduced live on beta.vegan.at: first SPA visit to `/newsletter` follows the redirect, second visit strands on `/newsletter` with the Startseite title. Reproduced the same in the playground e2e (red without this fix, green with it).

## Fix

Return a detached `ref(createEmptyPage())` from the redirect branch instead of writing the empty page through into the payload cache. The cache retains the redirect payload, so repeat visits re-run the redirect handling. SSR (real 301) and external redirects unchanged.

## Tests

- New browser e2e in `test/e2e/redirect.test.ts`: SPA navigation to a redirecting path, twice (the repeat visit is the regression case). Verified red on unfixed `2.x`, green with the fix.
- Playground: `/redirect-to-3` CE-API route + main-menu entry to click.
- Full suite `npm test`: 124 passed (one unrelated suite flaked on a busy port, passes in isolation). Pre-existing lint errors on `2.x` untouched.

Refs: MCD-1270

---
_Drafted with Claude Code from claude-vm-3._