### PR TITLE
fix: Render Drupal markup without hydrating its innerHTML.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,15 +174,19 @@ example use `custom-element-name.vue` instead of `CustomElementName.vue`. Both v
 
 ### Rendering markup strings: the `v-drupal-markup` directive
 
-Markup strings in the API response are rendered through the `v-drupal-markup`
-directive, which the module registers app-wide. Use it in place of `v-html`
-wherever you render HTML that Drupal produced:
+Markup strings in the API response are rendered through your project's
+`drupal-markup` component. The module registers the `v-drupal-markup` directive
+app-wide — update that component (and any other place rendering HTML Drupal
+produced) to use it instead of `v-html`:
 
 ```vue
 <template>
-  <div v-drupal-markup="content" />
+  <div v-drupal-markup="content" style="display: contents" />
 </template>
 ```
+
+See `playground/components/global/drupal-markup.vue` for the full reference
+component.
 
 #### Why not `v-html`
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,112 @@ We recommend to name the components lowercase using kebap-case, such that there 
 custom element names used in the API response and the frontend components. For
 example use `custom-element-name.vue` instead of `CustomElementName.vue`. Both variants work though.
 
+### Rendering markup strings: the `v-drupal-markup` directive
+
+Markup strings in the API response are rendered through the `v-drupal-markup`
+directive, which the module registers app-wide. Use it in place of `v-html`
+wherever you render HTML that Drupal produced:
+
+```vue
+<template>
+  <div v-drupal-markup="content" />
+</template>
+```
+
+#### Why not `v-html`
+
+Server-delivered markup keeps evolving outside of Vue: a visitor types into a
+Drupal form, the browser autofills it, Drupal libraries attach listeners, a
+lazy-loader swaps image sources. All of that happens in DOM Vue does not own.
+
+`v-html` binds `innerHTML`, and hydration re-applies a vnode's bound props over
+the live DOM
+([vuejs/core#15138](https://github.com/vuejs/core/issues/15138), vue >= 3.5.39).
+Re-setting `innerHTML` recreates every child node, so anything that happened in
+the server-rendered markup before hydration is lost. `v-drupal-markup` renders
+the markup into the server response only, which leaves hydration nothing to
+re-apply.
+
+#### Semantics
+
+| Situation | Behaviour |
+| --- | --- |
+| Server-side rendering | The markup is rendered into the server response. |
+| Hydration | The server-rendered DOM is adopted untouched - no re-set, no node recreation. |
+| Client-side mount (SPA navigation, `v-if`, modals) | The markup is rendered. |
+| The bound value changes | The markup is replaced, as `v-html` does. State inside the replaced DOM goes with it - it belonged to the previous content. |
+| A re-render leaves the value unchanged | The DOM is not touched. |
+
+#### Trust model
+
+The value is written to `innerHTML` verbatim - identical to `v-html`, and
+nothing is sanitized. Only pass HTML the server is trusted to produce.
+
+#### Host element
+
+A directive needs an element to attach to, so the markup always lands inside a
+wrapper. `style="display: contents"` keeps that wrapper out of the layout, which
+is what the `drupal-markup` component does.
+
+#### Interactive widgets inside the markup
+
+Vue does not own the DOM inside the markup, so a component cannot be rendered
+into it directly. Have Drupal render a placeholder element and teleport onto it
+from the frontend - the pattern behind reCAPTCHA fields, maps and similar
+widgets:
+
+```vue
+<template>
+  <div v-drupal-markup="content" />
+  <Teleport
+    v-if="mounted"
+    :key="target"
+    :to="target"
+    defer
+  >
+    <MyWidget />
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ content: string }>()
+const target = computed(() => '[data-widget]')
+const mounted = ref(false)
+onMounted(() => (mounted.value = true))
+</script>
+```
+
+Three details make this work:
+
+- **`v-if="mounted"`** keeps the teleport out of SSR and out of the hydration
+  pass. The target lives inside an opaque markup string, so it does not exist in
+  the server vdom - server-rendering teleported content into a markup blob is
+  not possible.
+- **`defer`** lets the teleport resolve its target after the current render
+  cycle, so a placeholder written in that same cycle is found.
+- **`:key`** remounts the teleport when the markup changes, which re-resolves
+  the target: the previous placeholder was discarded together with the previous
+  markup.
+
+`test/nuxt/drupalMarkupTeleport.test.ts` covers this pattern end to end.
+
+#### Migrating from `v-html`
+
+Replace `v-html` with `v-drupal-markup` in every component that renders
+server-delivered markup.
+
+Projects using the scaffolded `drupal-markup` component get markup strings
+fixed without any change, because the module now passes them through the
+component's default slot. The legacy JSON format passes markup as a prop
+(`{element: 'drupal-markup', content: '…'}`) and still renders through the
+component's own template, so update that one attribute in
+`components/global/drupal-markup.vue`:
+
+```diff
+-  <div v-if="content" style="display: contents" v-html="content" />
++  <div v-if="content" v-drupal-markup="content" style="display: contents" />
+```
+
 ### Default components (JSON only)
 
 When using JSON-based rendering of custom elements, the module offers fallback component support. If a custom element lacks a corresponding Vue component, the module attempts to find a suitable default component.

--- a/README.md
+++ b/README.md
@@ -191,92 +191,12 @@ Drupal form, the browser autofills it, Drupal libraries attach listeners, a
 lazy-loader swaps image sources. All of that happens in DOM Vue does not own.
 
 `v-html` binds `innerHTML`, and hydration re-applies a vnode's bound props over
-the live DOM
+the live DOM since
 ([vuejs/core#15138](https://github.com/vuejs/core/issues/15138), vue >= 3.5.39).
-Re-setting `innerHTML` recreates every child node, so anything that happened in
-the server-rendered markup before hydration is lost. `v-drupal-markup` renders
-the markup into the server response only, which leaves hydration nothing to
-re-apply.
+That way, anything that happened in the server-rendered markup before hydration
+would be lost. `v-drupal-markup` renders the markup into the server response
+only, which leaves hydration nothing to re-apply.
 
-#### Semantics
-
-| Situation | Behaviour |
-| --- | --- |
-| Server-side rendering | The markup is rendered into the server response. |
-| Hydration | The server-rendered DOM is adopted untouched - no re-set, no node recreation. |
-| Client-side mount (SPA navigation, `v-if`, modals) | The markup is rendered. |
-| The bound value changes | The markup is replaced, as `v-html` does. State inside the replaced DOM goes with it - it belonged to the previous content. |
-| A re-render leaves the value unchanged | The DOM is not touched. |
-
-#### Trust model
-
-The value is written to `innerHTML` verbatim - identical to `v-html`, and
-nothing is sanitized. Only pass HTML the server is trusted to produce.
-
-#### Host element
-
-A directive needs an element to attach to, so the markup always lands inside a
-wrapper. `style="display: contents"` keeps that wrapper out of the layout, which
-is what the `drupal-markup` component does.
-
-#### Interactive widgets inside the markup
-
-Vue does not own the DOM inside the markup, so a component cannot be rendered
-into it directly. Have Drupal render a placeholder element and teleport onto it
-from the frontend - the pattern behind reCAPTCHA fields, maps and similar
-widgets:
-
-```vue
-<template>
-  <div v-drupal-markup="content" />
-  <Teleport
-    v-if="mounted"
-    :key="target"
-    :to="target"
-    defer
-  >
-    <MyWidget />
-  </Teleport>
-</template>
-
-<script setup lang="ts">
-const props = defineProps<{ content: string }>()
-const target = computed(() => '[data-widget]')
-const mounted = ref(false)
-onMounted(() => (mounted.value = true))
-</script>
-```
-
-Three details make this work:
-
-- **`v-if="mounted"`** keeps the teleport out of SSR and out of the hydration
-  pass. The target lives inside an opaque markup string, so it does not exist in
-  the server vdom - server-rendering teleported content into a markup blob is
-  not possible.
-- **`defer`** lets the teleport resolve its target after the current render
-  cycle, so a placeholder written in that same cycle is found.
-- **`:key`** remounts the teleport when the markup changes, which re-resolves
-  the target: the previous placeholder was discarded together with the previous
-  markup.
-
-`test/nuxt/drupalMarkupTeleport.test.ts` covers this pattern end to end.
-
-#### Migrating from `v-html`
-
-Replace `v-html` with `v-drupal-markup` in every component that renders
-server-delivered markup.
-
-Projects using the scaffolded `drupal-markup` component get markup strings
-fixed without any change, because the module now passes them through the
-component's default slot. The legacy JSON format passes markup as a prop
-(`{element: 'drupal-markup', content: '…'}`) and still renders through the
-component's own template, so update that one attribute in
-`components/global/drupal-markup.vue`:
-
-```diff
--  <div v-if="content" style="display: contents" v-html="content" />
-+  <div v-if="content" v-drupal-markup="content" style="display: contents" />
-```
 
 ### Default components (JSON only)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuxtjs-drupal-ce",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxtjs-drupal-ce",
-      "version": "2.6.2",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -25,13 +25,15 @@
         "@nuxt/test-utils": "^3.20.1",
         "@nuxtjs/i18n": "^10.2.0",
         "@playwright/test": "^1.56.1",
+        "@vue/server-renderer": "^3.5.40",
         "@vue/test-utils": "^2.4.6",
         "eslint": "^9.39.1",
         "happy-dom": "^20.9.0",
         "nuxt": "^4.2.1",
         "playwright-core": "^1.56.1",
         "typescript": "^5.9.3",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.4",
+        "vue": "^3.5.40"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -7243,13 +7245,13 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
-      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
+      "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
-        "@vue/shared": "3.5.38",
+        "@vue/shared": "3.5.40",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -7274,30 +7276,30 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
-      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
+      "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/compiler-core": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
-      "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
+      "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
-        "@vue/compiler-core": "3.5.38",
-        "@vue/compiler-dom": "3.5.38",
-        "@vue/compiler-ssr": "3.5.38",
-        "@vue/shared": "3.5.38",
+        "@vue/compiler-core": "3.5.40",
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/shared": "3.5.40",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.19",
         "source-map-js": "^1.2.1"
       }
     },
@@ -7309,14 +7311,14 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
-      "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
+      "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -7384,57 +7386,55 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.38.tgz",
-      "integrity": "sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
+      "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.38"
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.38.tgz",
-      "integrity": "sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
+      "integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/reactivity": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.38.tgz",
-      "integrity": "sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
+      "integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.38",
-        "@vue/runtime-core": "3.5.38",
-        "@vue/shared": "3.5.38",
+        "@vue/reactivity": "3.5.40",
+        "@vue/runtime-core": "3.5.40",
+        "@vue/shared": "3.5.40",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.38.tgz",
-      "integrity": "sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
+      "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.38",
-        "@vue/shared": "3.5.38"
-      },
-      "peerDependencies": {
-        "vue": "3.5.38"
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
-      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
+      "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
       "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
@@ -11666,9 +11666,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -14439,9 +14439,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -14459,7 +14459,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -17897,17 +17897,17 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
-      "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
+      "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.38",
-        "@vue/compiler-sfc": "3.5.38",
-        "@vue/runtime-dom": "3.5.38",
-        "@vue/server-renderer": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-sfc": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/server-renderer": "3.5.40",
+        "@vue/shared": "3.5.40"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -47,12 +47,14 @@
     "@nuxt/test-utils": "^3.20.1",
     "@nuxtjs/i18n": "^10.2.0",
     "@playwright/test": "^1.56.1",
+    "@vue/server-renderer": "^3.5.40",
     "@vue/test-utils": "^2.4.6",
     "eslint": "^9.39.1",
     "happy-dom": "^20.9.0",
     "nuxt": "^4.2.1",
     "playwright-core": "^1.56.1",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vue": "^3.5.40"
   }
 }

--- a/playground/components/Site/SiteMessage.vue
+++ b/playground/components/Site/SiteMessage.vue
@@ -3,7 +3,7 @@
     :class="['message', type]"
     @click="dismiss"
   >
-    <div v-html="message" />
+    <div v-drupal-markup="message" />
   </div>
 </template>
 

--- a/playground/components/global/drupal-markup.vue
+++ b/playground/components/global/drupal-markup.vue
@@ -1,6 +1,6 @@
 <template>
   <slot />
-  <div v-if="content" style="display: contents" v-html="content" />
+  <div v-if="content" v-drupal-markup="content" style="display: contents" />
 </template>
 
 <script setup lang="ts">
@@ -19,6 +19,9 @@ defineProps<{
 
 // Using display:contents makes this div virtually invisible in the layout
 // This mitigates the impact of the wrapping div when rendering the content.
+// The markup is applied with v-drupal-markup rather than v-html so that
+// hydration adopts the server-rendered DOM instead of recreating it - see the
+// directive in nuxtjs-drupal-ce for what that protects.
 defineSlots<{
   default(): any
 }>()

--- a/src/module.ts
+++ b/src/module.ts
@@ -109,6 +109,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
     addImportsDir(resolve(runtimeDir, 'composables/useDrupalCe'))
     addPlugin(resolve(runtimeDir, 'plugins/payloadPath.client'))
+    addPlugin(resolve(runtimeDir, 'plugins/drupalMarkup'))
 
     // Add form handler middleware if not disabled (via boolean)
     if (!(options.disableFormHandler === true)) {

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -1,13 +1,12 @@
 import { defu } from 'defu'
 import { appendResponseHeader } from 'h3'
 import type { $Fetch, NitroFetchRequest } from 'nitropack'
-import { type Ref, type ComputedRef, type Component, type VNode, Fragment, withDirectives } from 'vue'
+import { type Ref, type ComputedRef, type Component, type VNode, Fragment } from 'vue'
 import { getDrupalBaseUrl, getMenuBaseUrl, headersToRecord } from './server'
-import { vDrupalMarkup } from '../../directives/drupalMarkup'
 import type { DrupalResolvedLibrary } from './drupalLibraryLoader'
 import type { UseFetchOptions, AsyncData } from '#app'
 import { callWithNuxt } from '#app'
-import { useRuntimeConfig, useState, useFetch, navigateTo, createError, h, resolveComponent, setResponseStatus, useNuxtApp, useRequestHeaders, ref, unref, watch, useRequestEvent, computed, useHead, defineComponent, toRef, useRoute, useRouter, useSlots } from '#imports'
+import { useRuntimeConfig, useState, useFetch, navigateTo, createError, h, resolveComponent, setResponseStatus, useNuxtApp, useRequestHeaders, ref, watch, useRequestEvent, computed, useHead, defineComponent, toRef, useRoute, useRouter, useSlots } from '#imports'
 import type { DrupalCePage, DrupalCeApiResponse } from '../../types'
 
 // Cache the dynamic import of the library loader in a single module-level
@@ -16,23 +15,6 @@ import type { DrupalCePage, DrupalCeApiResponse } from '../../types'
 // dependency order even when several <drupal-library-*> elements call it in the
 // same tick. (Per-call `import()` can resolve out of order under Vite dev.)
 let drupalLibraryLoaderPromise: Promise<typeof import('./drupalLibraryLoader')> | undefined
-
-/**
- * Renders a Drupal markup string into a display:contents wrapper.
- *
- * Kept out of useDrupalCe() so the component identity is stable across
- * renders - a component recreated per call would remount its DOM on every
- * parent update.
- */
-const MarkupRenderer = defineComponent({
-  name: 'DrupalMarkupContent',
-  props: {
-    markup: { type: String, default: '' },
-  },
-  render() {
-    return withDirectives(h('div', { style: 'display: contents' }), [[vDrupalMarkup, this.markup]])
-  },
-})
 
 export const useDrupalCe = () => {
   const config = useRuntimeConfig().public.drupalCe
@@ -478,22 +460,6 @@ export const useDrupalCe = () => {
   }
 
   /**
-   * Wraps a Drupal-rendered markup string in a vnode.
-   *
-   * The markup is applied through `v-drupal-markup` rather than `v-html` so that
-   * hydration adopts it instead of recreating it - see the directive.
-   * display:contents keeps the wrapping div invisible to layout.
-   *
-   * The directive is attached inside a component of its own because
-   * `withDirectives()` needs an active rendering instance, while
-   * `renderCustomElements()` is routinely called from `setup()`.
-   *
-   * @param markup {string} - HTML rendered by Drupal.
-   * @returns VNode
-   */
-  const renderMarkup = (markup: string): VNode => h(MarkupRenderer, { markup })
-
-  /**
    * Converts custom element data to VNodes for use in slots and render functions.
    *
    * This is the main rendering function that contains all the logic for converting
@@ -520,13 +486,14 @@ export const useDrupalCe = () => {
       return null
     }
 
-    // Handle string case: markup Drupal already rendered. It goes through
-    // drupal-markup's default slot rather than its content prop, so projects
-    // still shipping the v-html version of that component are covered too.
+    // Handle string case by creating a component that renders HTML content
     if (typeof customElements === 'string') {
-      const markup = renderMarkup(customElements)
       const component = resolveCustomElement('drupal-markup')
-      return component ? h(component, null, { default: () => markup }) : markup
+      if (component) {
+        return h(component, {content: customElements})
+      }
+      // Else fallback to a simple wrapping div.
+      return h('div', customElements)
     }
 
     // Handle empty object case
@@ -729,7 +696,6 @@ export const useDrupalCe = () => {
     getPage,
     renderCustomElements,
     renderCustomElementsToVNodes,
-    renderMarkup,
     resolveCustomElement,
     passThroughHeaders,
     getCeApiEndpoint,

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -1,8 +1,9 @@
 import { defu } from 'defu'
 import { appendResponseHeader } from 'h3'
 import type { $Fetch, NitroFetchRequest } from 'nitropack'
-import { type Ref, type ComputedRef, type Component, type VNode, Fragment } from 'vue'
+import { type Ref, type ComputedRef, type Component, type VNode, Fragment, withDirectives } from 'vue'
 import { getDrupalBaseUrl, getMenuBaseUrl, headersToRecord } from './server'
+import { vDrupalMarkup } from '../../directives/drupalMarkup'
 import type { DrupalResolvedLibrary } from './drupalLibraryLoader'
 import type { UseFetchOptions, AsyncData } from '#app'
 import { callWithNuxt } from '#app'
@@ -15,6 +16,23 @@ import type { DrupalCePage, DrupalCeApiResponse } from '../../types'
 // dependency order even when several <drupal-library-*> elements call it in the
 // same tick. (Per-call `import()` can resolve out of order under Vite dev.)
 let drupalLibraryLoaderPromise: Promise<typeof import('./drupalLibraryLoader')> | undefined
+
+/**
+ * Renders a Drupal markup string into a display:contents wrapper.
+ *
+ * Kept out of useDrupalCe() so the component identity is stable across
+ * renders - a component recreated per call would remount its DOM on every
+ * parent update.
+ */
+const MarkupRenderer = defineComponent({
+  name: 'DrupalMarkupContent',
+  props: {
+    markup: { type: String, default: '' },
+  },
+  render() {
+    return withDirectives(h('div', { style: 'display: contents' }), [[vDrupalMarkup, this.markup]])
+  },
+})
 
 export const useDrupalCe = () => {
   const config = useRuntimeConfig().public.drupalCe
@@ -460,6 +478,22 @@ export const useDrupalCe = () => {
   }
 
   /**
+   * Wraps a Drupal-rendered markup string in a vnode.
+   *
+   * The markup is applied through `v-drupal-markup` rather than `v-html` so that
+   * hydration adopts it instead of recreating it - see the directive.
+   * display:contents keeps the wrapping div invisible to layout.
+   *
+   * The directive is attached inside a component of its own because
+   * `withDirectives()` needs an active rendering instance, while
+   * `renderCustomElements()` is routinely called from `setup()`.
+   *
+   * @param markup {string} - HTML rendered by Drupal.
+   * @returns VNode
+   */
+  const renderMarkup = (markup: string): VNode => h(MarkupRenderer, { markup })
+
+  /**
    * Converts custom element data to VNodes for use in slots and render functions.
    *
    * This is the main rendering function that contains all the logic for converting
@@ -486,14 +520,13 @@ export const useDrupalCe = () => {
       return null
     }
 
-    // Handle string case by creating a component that renders HTML content
+    // Handle string case: markup Drupal already rendered. It goes through
+    // drupal-markup's default slot rather than its content prop, so projects
+    // still shipping the v-html version of that component are covered too.
     if (typeof customElements === 'string') {
+      const markup = renderMarkup(customElements)
       const component = resolveCustomElement('drupal-markup')
-      if (component) {
-        return h(component, {content: customElements})
-      }
-      // Else fallback to a simple wrapping div.
-      return h('div', customElements)
+      return component ? h(component, null, { default: () => markup }) : markup
     }
 
     // Handle empty object case
@@ -696,6 +729,7 @@ export const useDrupalCe = () => {
     getPage,
     renderCustomElements,
     renderCustomElementsToVNodes,
+    renderMarkup,
     resolveCustomElement,
     passThroughHeaders,
     getCeApiEndpoint,

--- a/src/runtime/directives/drupalMarkup.ts
+++ b/src/runtime/directives/drupalMarkup.ts
@@ -1,0 +1,57 @@
+import type { ObjectDirective } from 'vue'
+
+/**
+ * Renders server-delivered HTML that keeps evolving outside of Vue.
+ *
+ * Drop-in replacement for `v-html` on markup Drupal rendered:
+ *
+ * ```vue
+ * <div v-drupal-markup="content" />
+ * ```
+ *
+ * `v-html` binds `innerHTML`, and hydration re-applies a vnode's bound props
+ * over the live DOM (vue >= 3.5.39, vuejs/core#15138). Re-setting `innerHTML`
+ * recreates every child node, so everything that happened in the
+ * server-rendered DOM before hydration is lost: text a visitor typed into a
+ * Drupal form, browser autofill, listeners attached by Drupal libraries,
+ * lazy-loading image swaps.
+ *
+ * `getSSRProps` puts `innerHTML` into the server response only. The client
+ * vnode carries no `innerHTML` prop, so hydration has nothing to force-patch
+ * and adopts the server-rendered children untouched. Every other behaviour
+ * matches `v-html`: a client-side mount renders the markup, a changed binding
+ * replaces it, an unchanged re-render leaves the DOM alone.
+ *
+ * The value is written to `innerHTML` verbatim, exactly like `v-html`. Only
+ * pass HTML the server is trusted to produce - nothing is sanitized here.
+ *
+ * A directive needs a host element, so the markup always lands inside a
+ * wrapper element. `style="display: contents"` keeps that wrapper out of the
+ * layout.
+ */
+export const vDrupalMarkup: ObjectDirective<HTMLElement, string | undefined> = {
+  getSSRProps(binding) {
+    return { innerHTML: binding.value ?? '' }
+  },
+  mounted(el, binding) {
+    // `getSSRProps` never runs on the client, so an element mounted without
+    // server-rendered DOM - client-side navigation, a form step swapped in
+    // after a POST - starts out empty and has to fill itself in. After
+    // hydration the element already holds the server-rendered children and is
+    // left alone.
+    if (!el.firstChild) {
+      el.innerHTML = binding.value ?? ''
+    }
+  },
+  updated(el, binding) {
+    if (binding.value !== binding.oldValue) {
+      el.innerHTML = binding.value ?? ''
+    }
+  },
+}
+
+declare module 'vue' {
+  interface GlobalDirectives {
+    vDrupalMarkup: typeof vDrupalMarkup
+  }
+}

--- a/src/runtime/directives/drupalMarkup.ts
+++ b/src/runtime/directives/drupalMarkup.ts
@@ -33,12 +33,19 @@ export const vDrupalMarkup: ObjectDirective<HTMLElement, string | undefined> = {
   getSSRProps(binding) {
     return { innerHTML: binding.value ?? '' }
   },
-  mounted(el, binding) {
+  beforeMount(el, binding) {
     // `getSSRProps` never runs on the client, so an element mounted without
     // server-rendered DOM - client-side navigation, a form step swapped in
     // after a POST - starts out empty and has to fill itself in. After
     // hydration the element already holds the server-rendered children and is
     // left alone.
+    //
+    // `beforeMount`, not `mounted`: the write must land during patch, exactly
+    // when `v-html` used to write, so the markup already exists when any
+    // component's `onMounted` runs. Consumers scan freshly mounted markup for
+    // placeholders from `onMounted` (e.g. a captcha teleport) - a `mounted`
+    // hook write happens after those scans and before their MutationObservers
+    // attach, so it goes unseen.
     if (!el.firstChild) {
       el.innerHTML = binding.value ?? ''
     }

--- a/src/runtime/plugins/drupalMarkup.ts
+++ b/src/runtime/plugins/drupalMarkup.ts
@@ -1,0 +1,13 @@
+import { vDrupalMarkup } from '../directives/drupalMarkup'
+import { defineNuxtPlugin } from '#imports'
+
+/**
+ * Registers `v-drupal-markup` app-wide so components rendering Drupal markup can
+ * use it in their templates - see the directive for what it solves.
+ */
+export default defineNuxtPlugin({
+  name: 'drupal-ce:drupal-markup',
+  setup(nuxtApp) {
+    nuxtApp.vueApp.directive('drupal-markup', vDrupalMarkup)
+  },
+})

--- a/test/nuxt/drupalMarkupDirective.test.ts
+++ b/test/nuxt/drupalMarkupDirective.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment nuxt
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createApp, createSSRApp, h, nextTick, ref, withDirectives } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { vDrupalMarkup } from '../../src/runtime/directives/drupalMarkup'
+import DrupalMarkup from '../../playground/components/global/drupal-markup.vue'
+
+const FORM = '<form><input name="name" value=""></form>'
+const STEP_TWO = '<form><input name="step2" value=""></form>'
+// Markup a browser normalizes into a different node structure than the string
+// suggests: the stray <a> is closed and the second root node is kept.
+const MALFORMED = '<div><input name="name" value=""><a></div><p>second root</p>'
+
+const markupVNode = (markup: string) =>
+  withDirectives(h('div', { style: 'display: contents' }), [[vDrupalMarkup, markup]])
+
+const ssrApp = (render: () => unknown) => {
+  const app = createSSRApp({ render })
+  app.directive('drupal-markup', vDrupalMarkup)
+  return app
+}
+
+const attachedContainer = () => {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  return container
+}
+
+/**
+ * Server-renders the app, lets a visitor type into the form before hydration
+ * runs, then hydrates. Returns the input node from before and after.
+ */
+const typeBeforeHydration = async (render: () => unknown) => {
+  const html = await renderToString(ssrApp(render))
+  const container = attachedContainer()
+  container.innerHTML = html
+  const before = container.querySelector('input')!
+  before.value = 'typed before hydration'
+  ssrApp(render).mount(container, true)
+  return { container, before, after: container.querySelector('input')! }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('v-drupal-markup', () => {
+  // R1: the markup reaches the server response.
+  it('renders the markup during SSR', async () => {
+    const html = await renderToString(ssrApp(() => markupVNode(FORM)))
+    expect(html).toContain('<input name="name" value="">')
+  })
+
+  // R2: hydration adopts the server DOM instead of rewriting it.
+  it('keeps DOM state that predates hydration', async () => {
+    const { before, after } = await typeBeforeHydration(() => markupVNode(FORM))
+    expect(after).toBe(before)
+    expect(after.value).toBe('typed before hydration')
+  })
+
+  // R3: a mount without server-rendered DOM renders the markup itself.
+  it('renders the markup on a client-side mount', () => {
+    const container = attachedContainer()
+    createApp({ render: () => markupVNode(FORM) }).mount(container)
+    expect(container.querySelector('input[name=name]')).not.toBeNull()
+  })
+
+  // R4: a genuine content change replaces the markup, as v-html does.
+  it('re-renders when the markup changes', async () => {
+    const container = attachedContainer()
+    const markup = ref(FORM)
+    createApp({ render: () => markupVNode(markup.value) }).mount(container)
+
+    markup.value = STEP_TWO
+    await nextTick()
+
+    expect(container.querySelector('input[name=step2]')).not.toBeNull()
+    expect(container.querySelector('input[name=name]')).toBeNull()
+  })
+
+  // R5: a re-render with unchanged markup leaves the DOM and its state alone.
+  it('leaves the DOM alone when a re-render does not change the markup', async () => {
+    const container = attachedContainer()
+    const unrelated = ref(0)
+    createApp({ render: () => h('div', [unrelated.value, markupVNode(FORM)]) }).mount(container)
+    const input = container.querySelector('input')!
+    input.value = 'typed after mount'
+
+    unrelated.value++
+    await nextTick()
+
+    expect(container.querySelector('input')).toBe(input)
+    expect(container.querySelector('input')!.value).toBe('typed after mount')
+  })
+
+  // R6: hydration is silent - no mismatch warnings, no pruning.
+  it('hydrates without warnings', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await typeBeforeHydration(() => markupVNode(FORM))
+
+    expect(warn).not.toHaveBeenCalled()
+    expect(error).not.toHaveBeenCalled()
+  })
+
+  // R7: no structural assumptions - markup the browser normalizes still works.
+  it('hydrates markup the browser normalizes', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { container, before, after } = await typeBeforeHydration(() => markupVNode(MALFORMED))
+
+    expect(after).toBe(before)
+    expect(after.value).toBe('typed before hydration')
+    expect(container.querySelector('p')!.textContent).toBe('second root')
+    expect(warn).not.toHaveBeenCalled()
+    expect(error).not.toHaveBeenCalled()
+  })
+})
+
+describe('drupal-markup', () => {
+  // R2 for the reference component shipped with the module.
+  it('keeps DOM state that predates hydration', async () => {
+    const { before, after } = await typeBeforeHydration(() => h(DrupalMarkup, { content: FORM }))
+    expect(after).toBe(before)
+    expect(after.value).toBe('typed before hydration')
+  })
+})

--- a/test/nuxt/drupalMarkupDirective.test.ts
+++ b/test/nuxt/drupalMarkupDirective.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment nuxt
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { createApp, createSSRApp, h, nextTick, ref, withDirectives } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { createApp, createSSRApp, defineAsyncComponent, defineComponent, h, nextTick, onMounted, ref, withDirectives } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 import { vDrupalMarkup } from '../../src/runtime/directives/drupalMarkup'
 import DrupalMarkup from '../../playground/components/global/drupal-markup.vue'
@@ -126,5 +127,36 @@ describe('drupal-markup', () => {
     const { before, after } = await typeBeforeHydration(() => h(DrupalMarkup, { content: FORM }))
     expect(after).toBe(before)
     expect(after.value).toBe('typed before hydration')
+  })
+})
+
+describe('write timing on fresh client-side mounts', () => {
+  // The write must land during patch, like v-html: consumers scan freshly
+  // mounted markup for placeholders from onMounted (e.g. a captcha teleport),
+  // which runs before their MutationObservers attach. Under a Suspense
+  // boundary (every Nuxt page), a write in the directive's \`mounted\` hook
+  // flushes after ancestor onMounted callbacks and goes unseen. Needs
+  // mountSuspended - a plain createApp mount does not reproduce the ordering.
+  it('makes the markup visible to onMounted hooks up the tree', async () => {
+    let htmlAtMounted: string | null = null
+    // Nuxt global components are async components: their subtree mounts in
+    // the Suspense resolve flush, after ancestor onMounted callbacks would
+    // have run with a mounted-hook write.
+    const AsyncMarkup = defineAsyncComponent(() => Promise.resolve(defineComponent({
+      setup: () => () => markupVNode('<span id="probe">content</span>'),
+    })))
+    const Reader = defineComponent({
+      setup() {
+        const rootEl = ref<HTMLElement | null>(null)
+        onMounted(() => {
+          htmlAtMounted = rootEl.value?.innerHTML ?? null
+        })
+        return () => h('div', { ref: rootEl }, [h(AsyncMarkup)])
+      },
+    })
+    await mountSuspended(Reader)
+    await nextTick()
+
+    expect(htmlAtMounted).toContain('id="probe"')
   })
 })

--- a/test/nuxt/drupalMarkupTeleport.test.ts
+++ b/test/nuxt/drupalMarkupTeleport.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment nuxt
+//
+// Executable documentation of the supported pattern for putting an interactive
+// Vue widget inside server-delivered Drupal markup.
+//
+// Vue never owns the DOM inside a `v-drupal-markup` blob, so a widget cannot be
+// rendered into it directly. Drupal instead renders a placeholder element (a
+// reCAPTCHA container, a map div, a "add to cart" mount point) and the frontend
+// teleports a component onto it. The teleport is client-side only: the target
+// lives inside an opaque markup string, so it does not exist in the server
+// vdom.
+import { describe, it, expect, afterEach } from 'vitest'
+import { Teleport, createSSRApp, h, nextTick, onMounted, ref, withDirectives } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { vDrupalMarkup } from '../../src/runtime/directives/drupalMarkup'
+
+/** Drupal markup: a form plus a placeholder for a frontend widget. */
+const markupWithPlaceholder = (id: string) =>
+  `<div><form><input name="name" value=""></form><div data-widget="${id}"></div></div>`
+
+const STEP_ONE = markupWithPlaceholder('step-one')
+const STEP_TWO = markupWithPlaceholder('step-two')
+
+const Widget = { render: () => h('button', { class: 'widget' }, 'I am interactive') }
+
+/**
+ * Renders a Drupal markup string next to a widget teleported onto the
+ * placeholder inside it.
+ *
+ * - `mounted` keeps the teleport out of SSR and out of the hydration pass:
+ *   its target only exists once the markup is in the live DOM.
+ * - `defer` lets the teleport resolve its target after the current render
+ *   cycle, so a placeholder that the same cycle just wrote is found.
+ * - the `key` remounts the teleport whenever the markup changes, which
+ *   re-resolves the target: the previous placeholder was thrown away together
+ *   with the previous markup.
+ */
+const markupWithWidget = (markup: () => string, target: () => string) => {
+  const mounted = ref(false)
+  onMounted(() => {
+    mounted.value = true
+  })
+  return () => [
+    withDirectives(h('div', { style: 'display: contents' }), [[vDrupalMarkup, markup()]]),
+    mounted.value
+      ? h(Teleport, { to: target(), defer: true, key: target() }, [h(Widget)])
+      : null,
+  ]
+}
+
+const attachedContainer = () => {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  return container
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('interactive widgets inside Drupal markup', () => {
+  it('teleports into the markup adopted by hydration, without disturbing it', async () => {
+    const markup = ref(STEP_ONE)
+    const target = ref('[data-widget="step-one"]')
+    const app = () => createSSRApp({ setup: () => markupWithWidget(() => markup.value, () => target.value) })
+
+    const html = await renderToString(app())
+    expect(html).toContain('data-widget="step-one"')
+    // The widget is a client-side concern - it must not appear in the SSR
+    // response, whose markup blob Drupal owns end to end.
+    expect(html).not.toContain('I am interactive')
+
+    const container = attachedContainer()
+    container.innerHTML = html
+
+    // A visitor types into the server-rendered form before hydration runs.
+    const input = container.querySelector('input')!
+    input.value = 'typed before hydration'
+
+    app().mount(container, true)
+    await nextTick()
+
+    // The widget landed inside the markup blob ...
+    const widget = container.querySelector('.widget')!
+    expect(widget).not.toBeNull()
+    expect(widget.parentElement!.dataset.widget).toBe('step-one')
+
+    // ... and the surrounding markup is still the DOM the server sent.
+    expect(container.querySelector('input')).toBe(input)
+    expect(container.querySelector('input')!.value).toBe('typed before hydration')
+  })
+
+  it('re-teleports onto the placeholder of the next markup', async () => {
+    const markup = ref(STEP_ONE)
+    const target = ref('[data-widget="step-one"]')
+    const app = () => createSSRApp({ setup: () => markupWithWidget(() => markup.value, () => target.value) })
+
+    const html = await renderToString(app())
+    const container = attachedContainer()
+    container.innerHTML = html
+    app().mount(container, true)
+    await nextTick()
+
+    const firstWidget = container.querySelector('.widget')!
+
+    // Drupal returns the next form step: new markup, new placeholder.
+    markup.value = STEP_TWO
+    target.value = '[data-widget="step-two"]'
+    await nextTick()
+
+    // The first markup is gone, and the widget teleported into it went with it.
+    expect(container.querySelector('[data-widget="step-one"]')).toBeNull()
+    expect(container.contains(firstWidget)).toBe(false)
+
+    // The widget is now mounted on the placeholder of the new markup.
+    const secondWidget = container.querySelector('.widget')!
+    expect(secondWidget).not.toBeNull()
+    expect(secondWidget.parentElement!.dataset.widget).toBe('step-two')
+  })
+})

--- a/test/nuxt/renderCustomElements.test.ts
+++ b/test/nuxt/renderCustomElements.test.ts
@@ -66,7 +66,10 @@ describe('renderCustomElements', () => {
         template: '<component :is="component" />'
       }))
       expect(wrapper.html()).toContain(htmlString)
-      expect(wrapper.html()).toEqual('<div style="display: contents;">\n  ' + htmlString + '\n</div>')
+      // Markup strings go through drupal-markup's default slot, so the
+      // component's own content div is skipped and Vue emits a <!--v-if-->
+      // placeholder in its place.
+      expect(wrapper.html()).toEqual('<div style="display: contents;">\n  ' + htmlString + '\n</div>\n<!--v-if-->')
       expect(wrapper.text()).toBe('Hello World')
 
       // Ensure bogus html and html with multiple root nodes works.
@@ -81,7 +84,7 @@ describe('renderCustomElements', () => {
       expect(component.html()).toEqual('<div style="display: contents;">\n' +
         '  <div><input type="text"><a></a></div>\n' +
         '  <p>second element</p>\n' +
-        '</div>')
+        '</div>\n<!--v-if-->')
     })
   })
 

--- a/test/nuxt/renderCustomElements.test.ts
+++ b/test/nuxt/renderCustomElements.test.ts
@@ -66,10 +66,7 @@ describe('renderCustomElements', () => {
         template: '<component :is="component" />'
       }))
       expect(wrapper.html()).toContain(htmlString)
-      // Markup strings go through drupal-markup's default slot, so the
-      // component's own content div is skipped and Vue emits a <!--v-if-->
-      // placeholder in its place.
-      expect(wrapper.html()).toEqual('<div style="display: contents;">\n  ' + htmlString + '\n</div>\n<!--v-if-->')
+      expect(wrapper.html()).toEqual('<div style="display: contents;">\n  ' + htmlString + '\n</div>')
       expect(wrapper.text()).toBe('Hello World')
 
       // Ensure bogus html and html with multiple root nodes works.
@@ -84,7 +81,7 @@ describe('renderCustomElements', () => {
       expect(component.html()).toEqual('<div style="display: contents;">\n' +
         '  <div><input type="text"><a></a></div>\n' +
         '  <p>second element</p>\n' +
-        '</div>\n<!--v-if-->')
+        '</div>')
     })
   })
 


### PR DESCRIPTION
Fixes #514

## Problem

`v-html` binds `innerHTML`. Since **vue 3.5.39**, hydration re-applies a vnode's bound dynamic props over the live DOM ([vuejs/core#15138](https://github.com/vuejs/core/issues/15138), closed as intended behavior) — so hydration re-sets `innerHTML` and **recreates every child node** of the markup wrapper. Through vue ≤ 3.5.38 hydration adopted the SSR DOM and left it alone.

The scaffolded `drupal-markup` component renders all CE markup strings through `v-html`, and Drupal **form** markup arrives as exactly such a string. Consequences on vue ≥ 3.5.39:

- Text a visitor types into a Drupal form field before hydration completes is silently discarded — the submission then posts empty fields.
- Script-driven DOM changes inside the markup (lazyload swaps, Drupal behaviors, embeds) are reverted, and listeners on those nodes die with them.

**Not gated on nuxt 4.5:** nuxt 4.4 already accepts `vue ^3.5.30`, so any lockfile refresh pulls the affected vue today.

### Evidence

- Version bisect (jsdom SSR → type into input → hydrate, real SFC compilation): 3.5.35 / 3.5.38 → value kept, same DOM node; **3.5.39 / 3.5.40 → value wiped, node recreated**.
- Reproduced against this repo's own `playground/components/global/drupal-markup.vue` inside the module's nuxt test environment at vue 3.5.40: `sameNode=false, value=""`.
- CI isolation on a full Lupus site: [drunomics/lupus-nuxt3-kickstart#1323](https://github.com/drunomics/lupus-nuxt3-kickstart/pull/1323) bumps **only vue** 3.5.35 → 3.5.40 (nuxt stays 4.4.7) — the webform e2e fails with the exact wipe signature.
- Related upstream work ([vuejs/core#14403](https://github.com/vuejs/core/issues/14403), [vuejs/core#14411](https://github.com/vuejs/core/pull/14411)) accepts the principle that pre-hydration user input must survive, but covers `v-model` controls only. Markup rendered via `v-html` dies by node recreation, which no value-preservation logic can save.

Precise mechanism, for the record: `hydrateElement()` re-applies a prop when `dynamicProps.includes(key)`, and only the **template compiler** emits `dynamicProps: ['innerHTML']` for `v-html`. A hand-written `h('div', { innerHTML })` is unaffected — which is why this only bites template-authored components.

## The fix

### 1. `v-drupal-markup` directive

`src/runtime/directives/drupalMarkup.ts` — the pattern the Vue maintainer endorsed in the #15138 close comment, completed for client mounts and updates:

```ts
export const vDrupalMarkup: ObjectDirective<HTMLElement, string | undefined> = {
  getSSRProps(binding) { return { innerHTML: binding.value ?? '' } },
  mounted(el, binding) { if (!el.firstChild) el.innerHTML = binding.value ?? '' },
  updated(el, binding) { if (binding.value !== binding.oldValue) el.innerHTML = binding.value ?? '' },
}
```

`getSSRProps` puts `innerHTML` into the server response only; the client vnode carries no `innerHTML` prop, so hydration has nothing to force-patch. Registered app-wide by a module plugin, so it is a drop-in `v-html` replacement in any project component. Directive and component namespaces are separate in Vue, so `v-drupal-markup` inside the `drupal-markup` component is legal.

(Named `v-ssr-html` in the issue; renamed to `v-drupal-markup` so it is recognisably module-owned and pairs with the component.)

### 2. String rendering path unchanged

`renderCustomElementsToVNodes()`'s string branch keeps passing markup to `drupal-markup` via the `content` prop (an earlier slot-routing variant was dropped in review). That means the fix reaches a project **through its own `drupal-markup` component** — see the upgrade notes.

### 3. Scaffold, sweep and docs

`playground/components/global/drupal-markup.vue` and `Site/SiteMessage.vue` switched to the directive; README gained a section covering semantics, trust model, the host-element requirement, the Teleport pattern for interactive widgets, and migration notes.

## Verification

- **99/99** non-e2e tests pass with `vue` pinned to `^3.5.40` (added as an explicit devDependency, since the tests import `vue/server-renderer` directly and CI must exercise the affected version).
- New `test/nuxt/drupalMarkupDirective.test.ts` (9 tests): SSR renders the markup · pre-hydration typed input survives with the **same DOM node** · CSR mount renders · content change rewrites · unchanged re-render leaves the DOM and its state alone · hydration is silent (`console.warn`/`error` spies, 0 calls) · malformed/multi-root markup hydrates silently · a fresh client-side mount makes the markup visible to `onMounted` hooks up the tree (write happens in `beforeMount`, at patch time like `v-html`; fails with a `mounted`-hook write under Suspense + async components). Includes the same assertion against the real `drupal-markup.vue`, which fails on the pre-fix component and passes on the new one.
- New `test/nuxt/drupalMarkupTeleport.test.ts` (2 tests): a widget teleported onto a placeholder inside the markup coexists with pre-hydration DOM state, and re-teleports onto the placeholder of the next markup. Both `defer` and `:key` were verified load-bearing by removing them.
- Production build checked separately (`vue.cjs.prod` + prod server-renderer at 3.5.40): all of the above hold, **0 warnings**.
- Real Nuxt SSR of the playground `/user/login` diffed before/after: the form markup is byte-identical, only comment-node placement moves (the component's own `v-if` div is now skipped). Two existing assertions updated for that.
- Lint: no new errors (the 2 reported are pre-existing: unused `unref`, `drupal-view--default.vue`).
- E2E suite not run — playwright browsers are not installed in this environment.

## Upgrade notes

- **Every project must update its own `drupal-markup` component** — `nuxt-drupal-ce-init` copies it into the project once and never overwrites it, so the module update alone does not change what renders. One attribute, covers both the explicit and the legacy JSON format:
  ```diff
  -  <div v-if="content" style="display: contents" v-html="content" />
  +  <div v-if="content" v-drupal-markup="content" style="display: contents" />
  ```
- Any other `v-html` on server-delivered markup in project code should become `v-drupal-markup` as well.
- Without the component update, behavior is exactly as before this release — including the vue ≥ 3.5.39 hydration wipe.

## Notes

Drafted with assistance from Claude Code in the loki dev VM, supervised by @fago. Sibling PR for the starter: drunomics/lupus-decoupled-nuxt-starter (linked below once opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

