### PR TITLE
fix: ship the shared type declarations in the published package

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,6 @@
 import { defineNuxtModule, addPlugin, addServerPlugin, createResolver, addImportsDir, addServerHandler, addImports, installModule } from '@nuxt/kit'
 import { defu } from 'defu'
-import type { NuxtOptionsWithDrupalCe } from './types'
+import type { NuxtOptionsWithDrupalCe } from './runtime/types'
 
 function getCorsOrigin(nuxt: any): string | null {
   // Check environment variable first (higher priority), then runtimeConfig.
@@ -164,7 +164,7 @@ export default defineNuxtModule<ModuleOptions>({
     addImports([
       {
         name: 'CustomElementContent',
-        from: resolve('./types.d.ts'),
+        from: resolve('./runtime/types.d.ts'),
         type: true
       },
     ])

--- a/src/runtime/composables/useDrupalCe/index.ts
+++ b/src/runtime/composables/useDrupalCe/index.ts
@@ -559,7 +559,7 @@ export const useDrupalCe = () => {
    * <component :is> by wrapping VNode[] in a Component.
    *
    * @param customElements {CustomElementContent} - Custom element data to render.
-   *          See {@link https://github.com/drunomics/nuxtjs-drupal-ce/blob/2.x/src/types.d.ts} type definition for detailed structure documentation.
+   *          See {@link https://github.com/drunomics/nuxtjs-drupal-ce/blob/2.x/src/runtime/types.d.ts} type definition for detailed structure documentation.
    * @returns VNode | Component | null
    *          - VNode: For single elements and strings
    *          - Component: For arrays (wraps VNode[] in defineComponent for <component :is> compatibility)

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -1,4 +1,5 @@
-import type { ModuleOptions } from './module'
+import type { NuxtOptions } from '@nuxt/schema'
+import type { ModuleOptions } from '../module'
 
 /**
  * Explicit format custom element with separated props and slots

--- a/test/nuxt/components/preview.test.ts
+++ b/test/nuxt/components/preview.test.ts
@@ -4,7 +4,7 @@ import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 import App from '~/app.vue'
 
 describe('Preview routes', () => {
-  registerEndpoint('http://127.0.0.1:3001/ce-api/node/preview/node', () => ({
+  registerEndpoint('http://127.0.0.1:3021/ce-api/node/preview/node', () => ({
     content: {
       element: 'node-article',
       body: '<p>Some <b>example</b> body.</p>'
@@ -14,7 +14,7 @@ describe('Preview routes', () => {
     metatags: { meta: [], link: [], jsonld: [] }
   }))
 
-  registerEndpoint('http://127.0.0.1:3001/ce-api/node/5/layout-preview', () => ({
+  registerEndpoint('http://127.0.0.1:3021/ce-api/node/5/layout-preview', () => ({
     content: {
       element: 'node-article',
       body: '<p>Some <b>example</b> body.</p>'

--- a/test/nuxt/fetchPageAndMenu.test.ts
+++ b/test/nuxt/fetchPageAndMenu.test.ts
@@ -15,13 +15,13 @@ describe('fetchPage and fetchMenu use the right API endpoints', () => {
     registerEndpoint('/api/drupal-ce/test-page', () => ({
       content: { title: 'Via Proxy' }
     }))
-    registerEndpoint('http://127.0.0.1:3001/ce-api/test-page', () => ({
+    registerEndpoint('http://127.0.0.1:3021/ce-api/test-page', () => ({
       content: { title: 'Direct API' }
     }))
     registerEndpoint('/api/menu/api/menu_items/main', () => ({
       items: [{ title: 'Via Proxy Menu' }]
     }))
-    registerEndpoint('http://127.0.0.1:3001/ce-api/api/menu_items/main', () => ({
+    registerEndpoint('http://127.0.0.1:3021/ce-api/api/menu_items/main', () => ({
       items: [{ title: 'Direct API Menu' }]
     }))
   })
@@ -69,7 +69,7 @@ describe('fetchPage and fetchMenu use the right API endpoints', () => {
         registerEndpoint('/api/menu/fr/api/menu_items/main', () => ({
           items: [{ title: 'Via Proxy Menu FR' }]
         }))
-        registerEndpoint('http://127.0.0.1:3001/ce-api/fr/api/menu_items/main', () => ({
+        registerEndpoint('http://127.0.0.1:3021/ce-api/fr/api/menu_items/main', () => ({
           items: [{ title: 'Direct API Menu FR' }]
         }))
       })

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+import { describe, it, expect, beforeAll } from 'vitest'
+
+/**
+ * Guards the published package layout: the type declarations referenced by
+ * the module's `addImports()` call and by the runtime `.d.ts` files must
+ * actually be shipped in `dist`. Only `src/runtime/` is copied verbatim into
+ * the package — types living elsewhere under `src/` silently vanish from the
+ * npm tarball.
+ *
+ * Builds into a throwaway outDir so the stubbed `dist/` used by the other
+ * test files is not touched.
+ */
+describe('packaging', () => {
+  const rootDir = fileURLToPath(new URL('..', import.meta.url))
+  const outDir = 'node_modules/.cache/packaging-test-dist'
+  const dist = join(rootDir, outDir)
+
+  beforeAll(() => {
+    rmSync(dist, { recursive: true, force: true })
+    execFileSync(
+      join(rootDir, 'node_modules/.bin/nuxt-module-build'),
+      ['build', '--outDir', outDir],
+      { cwd: rootDir, stdio: 'pipe' },
+    )
+  }, 180_000)
+
+  it('ships the runtime type declarations', () => {
+    const typesFile = join(dist, 'runtime/types.d.ts')
+    expect(existsSync(typesFile), 'dist/runtime/types.d.ts must be shipped').toBe(true)
+    const content = readFileSync(typesFile, 'utf8')
+    for (const name of ['CustomElementContent', 'DrupalCePage', 'DrupalCeApiResponse']) {
+      expect(content).toMatch(new RegExp(`export (type|interface) ${name}\\b`))
+    }
+  })
+
+  it('addImports() points at a file that is shipped and exports the type', () => {
+    const moduleJs = readFileSync(join(dist, 'module.mjs'), 'utf8')
+    const match = moduleJs.match(/from:\s*resolve\(["']([^"']+)["']\)/)
+    expect(match, 'module.mjs must contain the type auto-import').toBeTruthy()
+    const target = join(dist, match![1])
+    expect(existsSync(target), `auto-import target ${match![1]} must exist in dist`).toBe(true)
+    expect(readFileSync(target, 'utf8')).toContain('CustomElementContent')
+  })
+
+  it('runtime .d.ts imports of the shared types resolve within dist', () => {
+    const composableDts = join(dist, 'runtime/composables/useDrupalCe/index.d.ts')
+    const content = readFileSync(composableDts, 'utf8')
+    const match = content.match(/from ["'](\.[^"']*types)(?:\.js)?["']/)
+    expect(match, 'composable .d.ts must import the shared types').toBeTruthy()
+    const resolved = join(dist, 'runtime/composables/useDrupalCe', `${match![1]}.d.ts`)
+    expect(existsSync(resolved), `${match![1]} must resolve to a shipped .d.ts`).toBe(true)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,14 +28,17 @@ export default defineConfig({
           include: ['test/nuxt/**/*.{test,spec}.ts'],
           environment: 'nuxt',
           environmentOptions: {
-            port: 3001,
+            // Own port: the six e2e suites built on nuxt.config4test.ts are
+            // locked to 3001 (self-referencing drupalBaseUrl), and vitest
+            // interleaves project files in one worker pool.
+            port: 3021,
             nuxt: {
               rootDir: fileURLToPath(new URL('./playground', import.meta.url)),
-              port: 3001,
+              port: 3021,
               overrides: {
                 modules: ['../dist/module.mjs'],
                 drupalCe: {
-                  drupalBaseUrl: 'http://127.0.0.1:3001',
+                  drupalBaseUrl: 'http://127.0.0.1:3021',
                   ceApiEndpoint: '/ce-api',
                 }
               }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
     projects: [
       {
         test: {
+          name: 'packaging',
+          include: ['test/packaging.test.ts'],
+          environment: 'node',
+        }
+      },
+      {
+        test: {
           name: 'e2e',
           include: ['test/e2e/*.{test,spec}.ts'],
           environment: 'node',


### PR DESCRIPTION
## Problem

`src/types.d.ts` (`CustomElementContent`, `DrupalCePage`, `DrupalCeApiResponse`, the `@nuxt/schema` runtimeConfig augmentation, …) is not part of the npm tarball — only `src/runtime/` is copied into `dist`. Consequences in every published version (verified against the 2.7.0 and 2.8.0 tarballs):

- The `CustomElementContent` type auto-import registered in `module.ts` points at `dist/types.d.ts`, which either doesn't exist (≤2.7.0 — surfaces as `WARN [NUXT_B6005] Could not resolve … types.d.ts` on nuxt 4.5) or is the module-builder shim that doesn't export the type (2.8.0).
- `dist/runtime/composables/useDrupalCe/index.d.ts` imports `DrupalCePage`/`DrupalCeApiResponse` from `../../types.js`, which doesn't exist in the tarball.
- The typed `runtimeConfig.public.drupalCe` augmentation never reaches consumers.

Everything only worked in the module repo's own stub/dev mode, where paths resolve into `src/`.

## Fix

- Move the declarations to `src/runtime/types.d.ts` — shipped verbatim in `dist/runtime/`. The composable's existing `../../types` import now resolves in both src and dist.
- Point the `addImports()` call and the `module.ts` import at the new location.
- New `test/packaging.test.ts` (own vitest project): runs a real `nuxt-module-build build` into a throwaway outDir and asserts the auto-import target and the runtime type imports resolve to shipped files exporting the types. All three tests fail on the previous layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)