### PR TITLE
chore: Require nuxt-component-preview >1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
-        "nuxt-component-preview": "^1.0.0-beta.9",
+        "nuxt-component-preview": "^1.1.0",
         "ufo": "^1.6.1"
       },
       "bin": {
@@ -6989,27 +6989,27 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.4.23",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.23.tgz",
-      "integrity": "sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
       "license": "MIT",
       "dependencies": {
-        "@volar/source-map": "2.4.23"
+        "@volar/source-map": "2.4.28"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.4.23",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.23.tgz",
-      "integrity": "sha512-Z1Uc8IB57Lm6k7q6KIDu/p+JWtf3xsXJqAX/5r18hYOTpJyBn0KXUR8oTJ4WFYOcDzWC9n3IflGgHowx6U6z9Q==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
-      "version": "2.4.23",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.23.tgz",
-      "integrity": "sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "2.4.23",
+        "@volar/language-core": "2.4.28",
         "path-browserify": "^1.0.1",
         "vscode-uri": "^3.0.8"
       }
@@ -7214,26 +7214,18 @@
       "license": "MIT"
     },
     "node_modules/@vue/language-core": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.5.tgz",
-      "integrity": "sha512-FMcqyzWN+sYBeqRMWPGT2QY0mUasZMVIuHvmb5NT3eeqPrbHBYtCP8JWEUCDCgM+Zr62uuWY/qoeBrPrzfa78w==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
+      "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "2.4.23",
+        "@volar/language-core": "2.4.28",
         "@vue/compiler-dom": "^3.5.0",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^3.0.0",
+        "alien-signals": "^3.2.1",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1",
-        "picomatch": "^4.0.2"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -7383,9 +7375,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.0.6.tgz",
-      "integrity": "sha512-gCs0YqC1mkYGC6IRXsSrA62ShOSv1FlVN5tRp/Cs2vRWLK/BAeluWIdfsl253pFQPznKEvRmHhfep7crWfyfWQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
       "license": "MIT"
     },
     "node_modules/ansi-regex": {
@@ -13021,12 +13013,49 @@
       }
     },
     "node_modules/nuxt-component-preview": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/nuxt-component-preview/-/nuxt-component-preview-1.0.0-beta.9.tgz",
-      "integrity": "sha512-+arUwRXrwyHPPEdpujvFIOiNb+8oi2SBGo9bvD47gihVos6SB9fLtg09aIydwTQG1/nuPnpo391+eOxwlT0xXA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nuxt-component-preview/-/nuxt-component-preview-1.1.1.tgz",
+      "integrity": "sha512-0HgyrFNWSEeL7vK+H5+sffrF/zoqvjtKVNz9trJjaGC+toHEz7XUhwLm1+oLgkArXhWAg1RAIxWUCeX2PYt91g==",
       "license": "MIT",
       "dependencies": {
-        "vue-component-meta": "^3.1.0"
+        "minimatch": "^10.0.3",
+        "vue-component-meta": "^3.3.9"
+      }
+    },
+    "node_modules/nuxt-component-preview/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/nuxt-component-preview/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/nuxt-component-preview/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nuxt-define": {
@@ -17049,6 +17078,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -18556,25 +18586,23 @@
       }
     },
     "node_modules/vue-component-meta": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/vue-component-meta/-/vue-component-meta-3.1.5.tgz",
-      "integrity": "sha512-HnCKlui/A37aBDypXpXID1IRkh+YJedTZ5S9aWjj4cUdIs0u9NBmApsv+p6fU7rX2FYqdscIuGpiJreEVN2Flg==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/vue-component-meta/-/vue-component-meta-3.3.9.tgz",
+      "integrity": "sha512-4u1VmMVjqs9BbKaISBZD7b+dNdqFteh5BYN8xVaXkjjJ66no1sRtDnS6aSs5/P5AzQQGPw10snHTf/z3HpBn2w==",
       "license": "MIT",
       "dependencies": {
-        "@volar/typescript": "2.4.23",
-        "@vue/language-core": "3.1.5",
-        "path-browserify": "^1.0.1",
-        "vue-component-type-helpers": "3.1.5"
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.9",
+        "path-browserify": "^1.0.1"
       },
       "peerDependencies": {
         "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/vue-component-meta/node_modules/vue-component-type-helpers": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.1.5.tgz",
-      "integrity": "sha512-7V3yJuNWW7/1jxCcI1CswnpDsvs02Qcx/N43LkV+ZqhLj2PKj50slUflHAroNkN4UWiYfzMUUUXiNuv9khmSpQ==",
-      "license": "MIT"
     },
     "node_modules/vue-component-type-helpers": {
       "version": "2.1.10",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "defu": "^6.1.4",
-    "nuxt-component-preview": "^1.0.0-beta.9",
+    "nuxt-component-preview": "^1.1.0",
     "ufo": "^1.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #524.

Raises the `nuxt-component-preview` floor from `^1.0.0-beta.9` to `^1.1.0`. The old caret range technically allowed 1.x already, but npm lockfile inertia keeps consumers on whatever they first resolved — and ncp < 1.1.0 has real defects this module inherits: an undeclared (phantom) `minimatch` dependency that crashes `nuxt prepare` when a CJS minimatch ≤5 is hoisted, and no `@schemaRef` type derivation, which silently degrades Canvas media pickers to plain text fields. The dependency range should state the actually-supported minimum.

Lockfile resolves ncp **1.1.1** (which properly declares `minimatch ^10` — nested 10.2.6 here).

Verified locally: nuxt project 99/99, e2e project 39/39.

---
Drafted with Claude Code from the loki dev VM.